### PR TITLE
Add Unofficial links section with full workflow integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_link_add.yaml
+++ b/.github/ISSUE_TEMPLATE/01_link_add.yaml
@@ -21,6 +21,16 @@ body:
       placeholder: e.g., https://www.my.af.mil
     validations:
       required: true
+  - type: dropdown
+    id: link_type
+    attributes:
+      label: Link Type
+      description: Official is a government (.mil / .gov) resource. Unofficial is a third-party tool or guide, shown in the separate Unofficial section.
+      options:
+        - Official
+        - Unofficial
+    validations:
+      required: true
   - type: textarea
     id: comment
     attributes:

--- a/.github/workflows/link_add.yml
+++ b/.github/workflows/link_add.yml
@@ -32,15 +32,20 @@ jobs:
 
         TITLE=$(field "Link Title")
         URL=$(field "Link URL")
+        LINK_TYPE=$(field "Link Type")
         [[ -z "$TITLE" ]] && { echo "Missing Link Title"; exit 1; }
         [[ -z "$URL" ]] && { echo "Missing Link URL"; exit 1; }
+        # Issues predating the Link Type dropdown have no such field: official
+        [[ "$LINK_TYPE" == "Unofficial" ]] || LINK_TYPE="Official"
 
         {
           echo "TITLE=$TITLE"
           echo "URL=$URL"
+          echo "LINK_TYPE=$LINK_TYPE"
         } >> "$GITHUB_ENV"
         echo "Parsed TITLE=$TITLE"
         echo "Parsed URL=$URL"
+        echo "Parsed LINK_TYPE=$LINK_TYPE"
 
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -61,13 +66,20 @@ jobs:
     - name: Add link to end of list with an auto-generated contentId
       run: |
         UUID=$(uuidgen)
-        jq -r --arg TITLE "${{ env.TITLE }}" --arg URL "${{ env.URL }}" --arg CONTENTID "$UUID" '.OTHER += [{"title": $TITLE, "link": $URL, "contentId": $CONTENTID}]' src/links/links_other.json | sponge src/links/links_other.json
-        cat src/links/links_other.json
+        if [[ "${{ env.LINK_TYPE }}" == "Unofficial" ]]; then
+          TARGET=src/links/links_unofficial.json
+          KEY=UNOFFICIAL
+        else
+          TARGET=src/links/links_other.json
+          KEY=OTHER
+        fi
+        jq -r --arg TITLE "${{ env.TITLE }}" --arg URL "${{ env.URL }}" --arg CONTENTID "$UUID" --arg KEY "$KEY" '.[$KEY] += [{"title": $TITLE, "link": $URL, "contentId": $CONTENTID}]' "$TARGET" | sponge "$TARGET"
+        cat "$TARGET"
 
     - name: Commit New Changes
       uses: EndBug/add-and-commit@v7
       with:
-        message: "Added link from issue: ${{ env.TITLE }}"
+        message: "Added ${{ env.LINK_TYPE }} link from issue: ${{ env.TITLE }}"
 
     - name: Trigger next workflow
       uses: actions/github-script@v6

--- a/.github/workflows/link_delete.yml
+++ b/.github/workflows/link_delete.yml
@@ -18,8 +18,18 @@ jobs:
         echo "Triggered by: ${{ github.event.client_payload.triggered_by }}"
         echo "Issue body: ${{ github.event.client_payload.issue_body }}"
 
-        # Parse the override issue body format
-        LINK_ID=$(echo "$BODY" | grep -A2 "### Link ID" | tail -n1 | xargs)
+        # Extract the first non-blank line after a "### <header>" line, trimmed.
+        # Anchoring on the header (rather than grep|xargs) survives blank-line
+        # shifts, CRLF payloads, and values containing quotes/apostrophes.
+        field() {
+          printf '%s' "$BODY" | awk -v H="### $1" '
+            index($0, H) == 1 { found = 1; next }
+            found && $0 ~ /[^[:space:]]/ {
+              sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); print; exit
+            }'
+        }
+
+        LINK_ID=$(field "Link ID")
 
         if [ -z "$LINK_ID" ]; then
           echo "Error: LINK_ID not found in issue body"
@@ -46,7 +56,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes jq moreutils
 
-    - name: Search links_other.json and links_af.json for Link ID
+    - name: Search link lists for Link ID
       run: |
         echo "Searching for LINK_ID: $LINK_ID"
 
@@ -54,6 +64,8 @@ jobs:
         if jq -e --arg id "$LINK_ID" '.OTHER[]? | select(.contentId == $id)' src/links/links_other.json >/dev/null 2>&1; then
           echo "FOUND_IN=links_other.json" >> $GITHUB_ENV
           echo "ACTION=remove" >> $GITHUB_ENV
+          echo "TARGET_FILE=src/links/links_other.json" >> $GITHUB_ENV
+          echo "TARGET_KEY=OTHER" >> $GITHUB_ENV
           echo "Found LINK_ID in src/links/links_other.json; will remove."
 
         # If not there, check links_af.json (AF categorized links) — we will create an override instead
@@ -62,21 +74,29 @@ jobs:
           echo "ACTION=override" >> $GITHUB_ENV
           echo "Found LINK_ID in src/links/links_af.json; will create override entry."
 
+        # Last, check links_unofficial.json — removed directly like OTHER
+        elif jq -e --arg id "$LINK_ID" '.UNOFFICIAL[]? | select(.contentId == $id)' src/links/links_unofficial.json >/dev/null 2>&1; then
+          echo "FOUND_IN=links_unofficial.json" >> $GITHUB_ENV
+          echo "ACTION=remove" >> $GITHUB_ENV
+          echo "TARGET_FILE=src/links/links_unofficial.json" >> $GITHUB_ENV
+          echo "TARGET_KEY=UNOFFICIAL" >> $GITHUB_ENV
+          echo "Found LINK_ID in src/links/links_unofficial.json; will remove."
+
         else
           echo "FOUND_IN=none" >> $GITHUB_ENV
           echo "ACTION=none" >> $GITHUB_ENV
-          echo "Error: LINK_ID '$LINK_ID' not found in either links_other.json or links_af.json"
+          echo "Error: LINK_ID '$LINK_ID' not found in links_other.json, links_af.json, or links_unofficial.json"
           exit 1
         fi
 
-    - name: Remove link from links_other.json
+    - name: Remove link from its list
       if: env.ACTION == 'remove'
       run: |
-        BEFORE_COUNT=$(jq '.OTHER | length' src/links/links_other.json)
+        BEFORE_COUNT=$(jq --arg KEY "${{ env.TARGET_KEY }}" '.[$KEY] | length' "${{ env.TARGET_FILE }}")
 
-        jq -r --arg LINK_ID "${{ env.LINK_ID }}" '.OTHER |= map(select(.contentId != $LINK_ID))' src/links/links_other.json | sponge src/links/links_other.json
+        jq -r --arg LINK_ID "${{ env.LINK_ID }}" --arg KEY "${{ env.TARGET_KEY }}" '.[$KEY] |= map(select(.contentId != $LINK_ID))' "${{ env.TARGET_FILE }}" | sponge "${{ env.TARGET_FILE }}"
 
-        AFTER_COUNT=$(jq '.OTHER | length' src/links/links_other.json)
+        AFTER_COUNT=$(jq --arg KEY "${{ env.TARGET_KEY }}" '.[$KEY] | length' "${{ env.TARGET_FILE }}")
 
         if [ "$BEFORE_COUNT" -eq "$AFTER_COUNT" ]; then
           echo "Warning: No items were removed. LINK_ID '${{ env.LINK_ID }}' may not exist."
@@ -85,7 +105,7 @@ jobs:
           echo "Successfully removed 1 item. Count: $BEFORE_COUNT -> $AFTER_COUNT"
         fi
 
-        cat src/links/links_other.json
+        cat "${{ env.TARGET_FILE }}"
 
     - name: Add override entry for links_af.json
       if: env.ACTION == 'override'
@@ -112,11 +132,11 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
+          await github.rest.issues.createComment({
+            issue_number: context.payload.client_payload.original_issue,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: ❌ Failed to remove link with Content ID `${{ env.LINK_ID }}` - it may not exist in the list.'
+            body: '❌ Failed to remove link with Content ID `${{ env.LINK_ID }}` - it may not exist in the list.'
           })
 
     - name: Commit New Changes

--- a/.github/workflows/link_override.yml
+++ b/.github/workflows/link_override.yml
@@ -101,7 +101,9 @@ jobs:
         # Look in links_other.json for a contentId match
         if jq -e --arg id "$LINK_ID" '.OTHER[]? | select(.contentId == $id)' src/links/links_other.json >/dev/null 2>&1; then
           echo "FOUND_IN=links_other.json" >> $GITHUB_ENV
-          echo "ACTION=edit_other" >> $GITHUB_ENV
+          echo "ACTION=edit_direct" >> $GITHUB_ENV
+          echo "TARGET_FILE=src/links/links_other.json" >> $GITHUB_ENV
+          echo "TARGET_KEY=OTHER" >> $GITHUB_ENV
           echo "Found in src/links/links_other.json; will update that file."
 
         # Else look in links_af.json for a contentId match
@@ -110,26 +112,35 @@ jobs:
           echo "ACTION=override" >> $GITHUB_ENV
           echo "Found in src/links/links_af.json; will add override entry."
 
+        # Else look in links_unofficial.json for a contentId match
+        elif jq -e --arg id "$LINK_ID" '.UNOFFICIAL[]? | select(.contentId == $id)' src/links/links_unofficial.json >/dev/null 2>&1; then
+          echo "FOUND_IN=links_unofficial.json" >> $GITHUB_ENV
+          echo "ACTION=edit_direct" >> $GITHUB_ENV
+          echo "TARGET_FILE=src/links/links_unofficial.json" >> $GITHUB_ENV
+          echo "TARGET_KEY=UNOFFICIAL" >> $GITHUB_ENV
+          echo "Found in src/links/links_unofficial.json; will update that file."
+
         else
           echo "FOUND_IN=none" >> $GITHUB_ENV
           echo "ACTION=none" >> $GITHUB_ENV
-          echo "Error: LINK_ID '$LINK_ID' not found in either links_other.json or links_af.json"
+          echo "Error: LINK_ID '$LINK_ID' not found in links_other.json, links_af.json, or links_unofficial.json"
           exit 1
         fi
 
-    - name: "Case: Overriding an OTHER link in links_other.json"
-      if: env.ACTION == 'edit_other'
+    - name: "Case: Editing a link in place (OTHER or UNOFFICIAL)"
+      if: env.ACTION == 'edit_direct'
       run: |
         set -o pipefail
         jq -r --arg id "${{ env.LINK_ID }}" \
            --arg NEW_TITLE "${{ env.NEW_TITLE }}" \
            --arg NEW_LINK "${{ env.NEW_LINK }}" \
-           '.OTHER |= map( if .contentId == $id then
+           --arg KEY "${{ env.TARGET_KEY }}" \
+           '.[$KEY] |= map( if .contentId == $id then
                (if $NEW_TITLE != "" and $NEW_TITLE != "null" and $NEW_TITLE != "_No response_" then .title = $NEW_TITLE else . end) |
                (if $NEW_LINK != "" and $NEW_LINK != "null" and $NEW_LINK != "_No response_" then .link = $NEW_LINK else . end)
-             else . end )' src/links/links_other.json | sponge src/links/links_other.json
+             else . end )' "${{ env.TARGET_FILE }}" | sponge "${{ env.TARGET_FILE }}"
 
-        echo "✅ Updated src/links/links_other.json for LINK_ID '${{ env.LINK_ID }}'"
+        echo "✅ Updated ${{ env.TARGET_FILE }} for LINK_ID '${{ env.LINK_ID }}'"
 
     - name: "Case: Overriding an AF Portal link in links_af.json via links_override.json"
       if: env.ACTION == 'override'

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -8,6 +8,7 @@ https://coolors.co/000000-a09200-695b24-73391d-b0aa7e
 .bg-olive-drab {background-color: #695B24; color: #fff;}
 .bg-spice-brown {background-color: #73391D; color: #fff;}
 .bg-cannes-blue {background-color: #7BAFD4; color: #fff;}
+.bg-slate-blue {background-color: #4F7396; color: #fff;}
 
 ul {
   list-style-type: none;  

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -111,6 +111,13 @@ ul {
   text-decoration: underline dotted #ff0000 1px;
 }
 
+/* Navbar group separators; only shown on the expanded (horizontal) bar */
+.navbar .nav-separator {
+  color: #ffffff66;
+  padding: 0.5rem 0.25rem;
+  user-select: none;
+}
+
 /* In-page navigation: smooth jumps from the sticky navbar, with scroll
    offset so section headings clear the bar */
 html {

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -110,6 +110,16 @@ ul {
   text-decoration: underline dotted #ff0000 1px;
 }
 
+/* In-page navigation: smooth jumps from the sticky navbar, with scroll
+   offset so section headings clear the bar */
+html {
+  scroll-behavior: smooth;
+}
+
+section[id] {
+  scroll-margin-top: 4rem;
+}
+
 /* Search-match highlighting. Zero padding: Bootstrap's default mark padding
    visually splits words mid-highlight. Cannes blue tint: the palette's one
    cool accent, complementary to the OCP earth tones around the white cards. */

--- a/src/includes/js/search.js
+++ b/src/includes/js/search.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
   
   // Show modal after clicking a link
   const my_modal = new bootstrap.Modal(document.getElementById('exit-modal'), {focus: false});
-  $("#link-list .list-group-item a:first-child").on('click', function(event) {
+  $("#link-list .list-group-item a:first-child, #unofficial-list .list-group-item a:first-child").on('click', function(event) {
     $('#exit-modal .modal-header .title').text($(this).text());
     $('#exit-modal .link').text($(this).prop('href'));
     my_modal.toggle();
@@ -87,11 +87,11 @@ $(document).ready(function () {
       }).filter(function (w) { return w.whole; });
 
       // Hide everything
-      $('#link-list .category, #link-list .link-container').toggle(false);
+      $('#link-list .category, #link-list .link-container, #unofficial-list .link-container').toggle(false);
 
       // Show links where every word matches the title or the URL,
       // highlighting title matches
-      var links = $('#link-list .link-container').filter(function(){
+      var links = $('#link-list .link-container, #unofficial-list .link-container').filter(function(){
         var $a = $(this).find('a:first-child');
         var text = $a.text();
         var title = normalize(text);
@@ -134,25 +134,29 @@ $(document).ready(function () {
       // Show link category
       links.siblings('.category').toggle(true);
 
+      // Hide the unofficial section entirely when none of its links match
+      $('#unofficial').toggle($('#unofficial-list .link-container:visible').length > 0);
+
       // Update URL with new search params
       updateSearchParams($(this).val())
 
       // If no links displayed, show alert
-      if (!$("#link-list a:visible")[0]) {
+      if (!$("#link-list a:visible, #unofficial-list a:visible")[0]) {
         $("#list p").removeAttr('hidden');
         $("#list p em").text(value);
       } else {
         $("#list p").attr('hidden','hidden');
       }
 
-      // On enter keypress, follow first link
+      // On enter keypress, follow first link (official list first in DOM order)
       if (
         value &&
         event.type === "keyup" &&
         event.originalEvent.key === "Enter"
       ) {
-        if ($("#link-list a:visible")[0]) {
-          $("#link-list a:visible")[0].click();
+        var first = $("#link-list a:visible, #unofficial-list a:visible")[0];
+        if (first) {
+          first.click();
         }
       }
     }

--- a/src/includes/update.pug
+++ b/src/includes/update.pug
@@ -11,7 +11,7 @@ section#update.bg-olive-drab.text-center
             .card.h-100.bg-dark.text-white.border-secondary
               .card-body.d-flex.flex-column
                 h5.card-title Add a New Link
-                p.card-text.flex-grow-1 Add a link to the OTHER category
+                p.card-text.flex-grow-1 Add an Official (OTHER) or Unofficial link
                 a(href='https://github.com/dadatuputi/aflink/issues/new?template=01_link_add.yaml').btn.btn-outline-light.mt-auto.d-flex.align-items-center.justify-content-center
                   img(width='20' src='/static/github.svg' alt='GitHub').me-2
                   | Submit Request

--- a/src/includes/update.pug
+++ b/src/includes/update.pug
@@ -11,7 +11,7 @@ section#update.bg-olive-drab.text-center
             .card.h-100.bg-dark.text-white.border-secondary
               .card-body.d-flex.flex-column
                 h5.card-title Add a New Link
-                p.card-text.flex-grow-1 Add an Official (OTHER) or Unofficial link
+                p.card-text.flex-grow-1 Suggest a link for the Official or Unofficial section
                 a(href='https://github.com/dadatuputi/aflink/issues/new?template=01_link_add.yaml').btn.btn-outline-light.mt-auto.d-flex.align-items-center.justify-content-center
                   img(width='20' src='/static/github.svg' alt='GitHub').me-2
                   | Submit Request

--- a/src/index.pug
+++ b/src/index.pug
@@ -54,8 +54,8 @@ html.bg-spice-brown(lang='en')
           each link in unofficial
             .list-group-item.list-group-item-action.border-top.link-container
               a.main-link(href=link.link data-content-id=(link.contentId) title=link.title) #{link.title}
-        p.small.mt-2
-          a.text-reset(href='https://github.com/dadatuputi/aflink/issues/new/choose') Suggest an addition or change
+              a.override-link(target="_blank" title=("Correct link ID " + link.contentId) href=link.correction) 📝
+              a.override-link(target="_blank" title=("Delete link ID " + link.contentId) href=link.deletion) 🗑️
   section#about.bg-olive-drab.text-center
     .container
       h2 About

--- a/src/index.pug
+++ b/src/index.pug
@@ -40,8 +40,20 @@ html.bg-spice-brown(lang='en')
                   a.main-link(href=link.link class={'overridden': link.isOverridden} data-content-id=(link.contentId) title=(link.isOverridden ? 'Overridden ' + link.overriddenTimestamp + '; Original: ' + link.overridden: title=link.title)) #{link.title}
                   a.override-link(target="_blank" title=("Correct link ID " + link.contentId) href=link.correction) 📝
                   a.override-link(target="_blank" title=("Delete link ID " + link.contentId) href=link.deletion) 🗑️
-      p.alert-dark(hidden) No results for 
+      p.alert-dark(hidden) No results for
         em
+  if unofficial && unofficial.length > 0
+    section#unofficial.bg-bagby-green.text-center
+      .container
+        .offcenter
+          h2 Unofficial
+        p.small.fst-italic.mb-2 Community-curated third-party tools. Not official DoD/USAF sites — not endorsed; use your own judgment.
+        div#unofficial-list.list-group
+          each link in unofficial
+            .list-group-item.list-group-item-action.border-top.link-container
+              a.main-link(href=link.link data-content-id=(link.contentId) title=link.title) #{link.title}
+        p.small.mt-2
+          a.text-reset(href='https://github.com/dadatuputi/aflink/issues/new/choose') Suggest an addition or change
   section#about.bg-olive-drab.text-center
     .container
       h2 About

--- a/src/index.pug
+++ b/src/index.pug
@@ -5,6 +5,8 @@ html.bg-spice-brown(lang='en')
 
   //- Navigation
   +navigation
+    a.nav-link(href='#list') Official
+    a.nav-link(href='#unofficial') Unofficial
     a.nav-link(href='#about') About
     a.nav-link(href='#update') Update Links
     a.nav-link(href='/tutorial') Tutorial
@@ -24,7 +26,7 @@ html.bg-spice-brown(lang='en')
   section#list.bg-sage.text-center
     .container
       .offcenter
-        h2 Link List
+        h2 Official Links
         em.d-none.d-md-block Synced #{date}
       div#link-list.list-group
         //- Links json is expanded here
@@ -46,7 +48,7 @@ html.bg-spice-brown(lang='en')
     section#unofficial.bg-bagby-green.text-center
       .container
         .offcenter
-          h2 Unofficial
+          h2 Unofficial Links
         p.small.fst-italic.mb-2 Community-curated third-party tools. Not official DoD/USAF sites — not endorsed; use your own judgment.
         div#unofficial-list.list-group
           each link in unofficial

--- a/src/index.pug
+++ b/src/index.pug
@@ -7,8 +7,11 @@ html.bg-spice-brown(lang='en')
   +navigation
     a.nav-link(href='#list') Official
     a.nav-link(href='#unofficial') Unofficial
+    span.nav-separator.d-none.d-lg-inline= '|'
     a.nav-link(href='#about') About
+    span.nav-separator.d-none.d-lg-inline= '|'
     a.nav-link(href='#update') Update Links
+    span.nav-separator.d-none.d-lg-inline= '|'
     a.nav-link(href='/tutorial') Tutorial
 
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -45,7 +45,7 @@ html.bg-spice-brown(lang='en')
       p.alert-dark(hidden) No results for
         em
   if unofficial && unofficial.length > 0
-    section#unofficial.bg-bagby-green.text-center
+    section#unofficial.bg-slate-blue.text-center
       .container
         .offcenter
           h2 Unofficial Links

--- a/src/links/links_unofficial.json
+++ b/src/links/links_unofficial.json
@@ -1,0 +1,19 @@
+{
+  "UNOFFICIAL": [
+    {
+      "title": "AF Bullet Shaper (pdf-bullets)",
+      "link": "https://af-vcd.github.io/pdf-bullets/",
+      "contentId": "uAFBULLETSHAPER"
+    },
+    {
+      "title": "MilitaryCAC (CAC setup and troubleshooting)",
+      "link": "https://militarycac.com/",
+      "contentId": "uMILITARYCAC"
+    },
+    {
+      "title": "Install DoD Certificates on macOS (governmentmac)",
+      "link": "https://governmentmac.com/install-dod-certificates-mac/",
+      "contentId": "uDODCERTSMAC"
+    }
+  ]
+}

--- a/updater.js
+++ b/updater.js
@@ -90,9 +90,15 @@ async function getNewestDate(files) {
         const linksOtherPath = path.resolve(linksDir, 'links_other.json')
         const linksOverridePath = path.resolve(linksDir, 'links_override.json')
 
+        const linksUnofficialPath = path.resolve(linksDir, 'links_unofficial.json')
+
         const links_af = JSON.parse(fs.readFileSync(linksAfPath));
         let links_other = JSON.parse(fs.readFileSync(linksOtherPath));
         const links_override = JSON.parse(fs.readFileSync(linksOverridePath));
+        // Unofficial third-party links stay out of the official links object so
+        // the override/delete workflows and links.json never touch them.
+        const links_unofficial = JSON.parse(fs.readFileSync(linksUnofficialPath)).UNOFFICIAL
+            .sort((a, b) => a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1);
 
         // Sort other links
         links_other = {
@@ -260,9 +266,10 @@ async function getNewestDate(files) {
         }
 
         // write homepage
-        const pageHome = pug.renderFile(path.resolve(srcDir, "index.pug"), { 
-            ...options, 
-            links, 
+        const pageHome = pug.renderFile(path.resolve(srcDir, "index.pug"), {
+            ...options,
+            links,
+            unofficial: links_unofficial,
             date,
             isDev: environment !== 'production'
         })

--- a/updater.js
+++ b/updater.js
@@ -222,30 +222,30 @@ async function getNewestDate(files) {
         console.log(`Wrote links.json`);
 
 
-        // Add correction url to each link
+        // Add correction url to each link (official and unofficial)
         const githubIssueBase = "https://github.com/dadatuputi/aflink/issues/new"
-        links.forEach(category => {
-            category.links.forEach(link => {
-                // GitHub's issue form locks any field prefilled via query param to
-                // that value — user edits revert on the form's next re-render.
-                // new_title/new_url must start empty so edits stick; the current
-                // values go in the reference-only current_* fields instead, where
-                // the lock is harmless.
-                const correction = new URL(githubIssueBase);
-                correction.searchParams.append('template', '02_link_override.yaml');
-                correction.searchParams.append('title', `[MODIFY]: ${link.title}`);
-                correction.searchParams.append('match', link.contentId);
-                correction.searchParams.append('current_title', link.title);
-                correction.searchParams.append('current_url', link.link);
-                link.correction = correction.toString();
+        const addIssueUrls = link => {
+            // GitHub's issue form locks any field prefilled via query param to
+            // that value — user edits revert on the form's next re-render.
+            // new_title/new_url must start empty so edits stick; the current
+            // values go in the reference-only current_* fields instead, where
+            // the lock is harmless.
+            const correction = new URL(githubIssueBase);
+            correction.searchParams.append('template', '02_link_override.yaml');
+            correction.searchParams.append('title', `[MODIFY]: ${link.title}`);
+            correction.searchParams.append('match', link.contentId);
+            correction.searchParams.append('current_title', link.title);
+            correction.searchParams.append('current_url', link.link);
+            link.correction = correction.toString();
 
-                const deletion = new URL(githubIssueBase);
-                deletion.searchParams.append('template', '03_link_delete.yaml');
-                deletion.searchParams.append('title', `[DELETE]: ${link.title}`);
-                deletion.searchParams.append('match', link.contentId);
-                link.deletion = deletion.toString();
-            });
-        });
+            const deletion = new URL(githubIssueBase);
+            deletion.searchParams.append('template', '03_link_delete.yaml');
+            deletion.searchParams.append('title', `[DELETE]: ${link.title}`);
+            deletion.searchParams.append('match', link.contentId);
+            link.deletion = deletion.toString();
+        };
+        links.forEach(category => category.links.forEach(addIssueUrls));
+        links_unofficial.forEach(addIssueUrls);
 
         console.log(`Combined ${links_length} links with ${override_count}/${links_override.length} overrides applied`)
 


### PR DESCRIPTION
Adds a separate, clearly-marked Unofficial section for third-party links, closing #105 and #110.

## What's included

- **Unofficial section** on the homepage (muted steel blue band below Official Links), sourced from
  `src/links/links_unofficial.json` — kept out of the official links object so the AF sync and
  `links.json` export never touch it. Seeded with AF Bullet Shaper (#105), MilitaryCAC, and the
  Mac DoD-cert guide (#110). Hidden entirely if the list is ever empty.
- **Full pipeline parity**: unofficial rows get the same 📝/🗑 hover icons; the override and delete
  workflows search `links_other.json` → `links_af.json` → `links_unofficial.json` and edit/remove
  in place. The add-link form gains a required **Link Type** dropdown (Official / Unofficial) that
  routes new links to the right file; pre-dropdown issues default to Official.
- **Navigation**: sections labeled Official Links / Unofficial Links, sticky-bar jump links with
  pipe group separators (`Home Official Unofficial | About | Update Links | Tutorial`), smooth
  CSS-only scrolling with scroll-margin offset.
- **Search integration**: unofficial links filter and highlight like official ones; the section
  hides when nothing in it matches; "No results" fires only when both lists are empty.
- **Drive-by fixes** in `link_delete.yml`: legacy `grep|xargs` parsing replaced with the
  header-anchored `awk` extractor (crashes on apostrophes otherwise), and the failure-comment step
  had a JS syntax error plus wrong issue-number context.

## Testing

- Built and verified locally (dev build + serve): section rendering, icons, search/highlight
  behavior, nav jumps, mobile collapse.
- Not testable until merge: the Link Type dropdown and unofficial issue routing (GitHub renders
  issue forms from the default branch only). Post-merge test: file an add-link issue with type
  Unofficial, then a 📝 correction against a seeded unofficial link.

Closes #105
Closes #110
