### PR TITLE
Search matches categories, with highlight + CATEGORY MATCH pill

### DIFF
--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -131,10 +131,50 @@ section[id] {
 /* Search-match highlighting. Zero padding: Bootstrap's default mark padding
    visually splits words mid-highlight. Cannes blue tint: the palette's one
    cool accent, complementary to the OCP earth tones around the white cards. */
-.main-link mark {
+.main-link mark,
+.category mark,
+#unofficial h2 mark {
   padding: 0;
   background-color: rgba(123, 175, 212, 0.45);
   border-radius: 2px;
+}
+
+/* CATEGORY MATCH pill: signals that the category name, not the link titles,
+   is why these rows are showing */
+.category-match-pill {
+  background-color: #4F7396;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  white-space: nowrap;
+}
+
+.category {
+  position: relative;
+}
+
+.category .category-match-pill {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+#unofficial h2 .category-match-pill {
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+/* On narrow screens the highlight alone carries it; the pill would crowd the
+   centered header */
+@media (max-width: 575.98px) {
+  .category .category-match-pill {
+    display: none;
+  }
 }
 
 /* Overrides page: truncate long URLs to fit; the full link shows on hover

--- a/src/includes/js/search.js
+++ b/src/includes/js/search.js
@@ -96,6 +96,10 @@ $(document).ready(function () {
         var text = $a.text();
         var title = normalize(text);
         var url = normalize(($a.attr('href') || "").replace(/^https?:\/\//, "")).norm;
+        // Tokens can also match the row's category name ("education" shows the
+        // whole category); unofficial rows have no .category sibling and match
+        // as "unofficial"
+        var cat = normalize($(this).siblings('.category').text() || "unofficial").norm;
         var ranges = [];
         var ok = words.every(function (w) {
           var p = title.norm.indexOf(w.whole);
@@ -103,7 +107,7 @@ $(document).ready(function () {
             ranges.push([title.map[p], title.map[p + w.whole.length - 1]]);
             return true;
           }
-          if (url.indexOf(w.whole) > -1) return true;
+          if (url.indexOf(w.whole) > -1 || cat.indexOf(w.whole) > -1) return true;
           if (!w.parts.length) return false;
           var partRanges = [];
           var all = w.parts.every(function (t) {
@@ -112,7 +116,7 @@ $(document).ready(function () {
               partRanges.push([title.map[q], title.map[q + t.length - 1]]);
               return true;
             }
-            return url.indexOf(t) > -1;
+            return url.indexOf(t) > -1 || cat.indexOf(t) > -1;
           });
           if (all) {
             ranges.push.apply(ranges, partRanges);

--- a/src/includes/js/search.js
+++ b/src/includes/js/search.js
@@ -138,8 +138,10 @@ $(document).ready(function () {
       // Show link category
       links.siblings('.category').toggle(true);
 
-      // Hide the unofficial section entirely when none of its links match
-      $('#unofficial').toggle($('#unofficial-list .link-container:visible').length > 0);
+      // Hide the unofficial section entirely when none of its links match.
+      // Count matches from the filter result, not :visible — rows inside the
+      // hidden section always measure invisible, which would latch it hidden.
+      $('#unofficial').toggle(links.filter('#unofficial-list .link-container').length > 0);
 
       // Update URL with new search params
       updateSearchParams($(this).val())

--- a/src/includes/js/search.js
+++ b/src/includes/js/search.js
@@ -68,6 +68,12 @@ $(document).ready(function () {
     $a.html(html + escapeHtml(text.slice(pos)));
   }
 
+  // Remember pristine header text: search decorates headers with a highlight
+  // and a CATEGORY MATCH pill, and matching must read the original text
+  $('#link-list .category, #unofficial h2').each(function () {
+    $(this).data('orig-text', $(this).text());
+  });
+
   // Filter links based on search query
   $("#search-form").on(
     "change keyup paste search",
@@ -99,7 +105,8 @@ $(document).ready(function () {
         // Tokens can also match the row's category name ("education" shows the
         // whole category); unofficial rows have no .category sibling and match
         // as "unofficial"
-        var cat = normalize($(this).siblings('.category').text() || "unofficial").norm;
+        var $cat = $(this).siblings('.category');
+        var cat = normalize($cat.length ? $cat.data('orig-text') : "unofficial").norm;
         var ranges = [];
         var ok = words.every(function (w) {
           var p = title.norm.indexOf(w.whole);
@@ -137,6 +144,39 @@ $(document).ready(function () {
 
       // Show link category
       links.siblings('.category').toggle(true);
+
+      // Decorate headers whose name matched a query word: highlight the
+      // matched text and append a CATEGORY MATCH pill
+      $('#link-list .category, #unofficial h2').each(function () {
+        var $h = $(this);
+        var htext = $h.data('orig-text');
+        var n = normalize(htext);
+        var hranges = [];
+        words.forEach(function (w) {
+          var p = n.norm.indexOf(w.whole);
+          if (p > -1) {
+            hranges.push([n.map[p], n.map[p + w.whole.length - 1]]);
+            return;
+          }
+          if (!w.parts.length) return;
+          var pr = [];
+          var all = w.parts.every(function (t) {
+            var q = n.norm.indexOf(t);
+            if (q > -1) {
+              pr.push([n.map[q], n.map[q + t.length - 1]]);
+              return true;
+            }
+            return false;
+          });
+          if (all) hranges.push.apply(hranges, pr);
+        });
+        if (hranges.length) {
+          highlight($h, htext, hranges);
+          $h.append('<span class="category-match-pill">Category match</span>');
+        } else {
+          $h.text(htext);
+        }
+      });
 
       // Hide the unofficial section entirely when none of its links match.
       // Count matches from the filter result, not :visible — rows inside the


### PR DESCRIPTION
Closes out the "category filtering" item from #51.

## What's included

- **Category matching**: query words also match category names, so "education" surfaces the
  whole EDUCATION TRAINING/ FORCE DEVELOPMENT block and "dod" pulls DEPARTMENT OF DEFENSE.
  Unofficial rows match "unofficial" as their pseudo-category.
- **Category-match indicator**: when a category name is why rows are showing, the header gets
  the same Cannes-blue highlight the titles use plus a steel blue CATEGORY MATCH pill
  (right-aligned in the header band; inline on the Unofficial section heading). The pill hides
  below the sm breakpoint, where the highlight alone carries the signal. Matching reads
  pristine header text stashed at load, so the pill text can never become a match itself.
- **Bug fix**: the Unofficial section could never reappear after any no-match query — the
  visibility check used jQuery `:visible` on rows inside the already-hidden section, which
  always measure invisible, latching it hidden. It now counts matches from the filter result.

## Testing

Built and verified locally: category queries ("education", "dod", "unofficial"), highlight and
pill rendering, section reappearing after clearing a no-match query, mobile pill hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
