### PR TITLE
Analytics page, nightly GA4 pull, and data-driven announcements

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -1,0 +1,48 @@
+name: Analytics Pull
+
+on:
+  schedule:
+    - cron: '17 9 * * *'   # daily, 09:17 UTC (off the hour to dodge cron congestion)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Fetch GA4 report
+        env:
+          GA4_CREDENTIALS: ${{ secrets.GA4_CREDENTIALS }}
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: node scripts/fetch-analytics.js
+
+      - name: Commit analytics.json
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: src/analytics.json
+          message: 'Update analytics data'
+
+      - name: Trigger site build
+        if: github.ref == 'refs/heads/master'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'build',
+              client_payload: {
+                commit_sha: context.sha,
+                message: 'Updated analytics data'
+              }
+            });

--- a/scripts/fetch-analytics.js
+++ b/scripts/fetch-analytics.js
@@ -1,0 +1,111 @@
+// Pull anonymized usage stats from the GA4 Data API and write src/analytics.json.
+//
+// Auth is a service-account JWT signed locally with Node's crypto — no npm
+// dependencies. Requires env vars:
+//   GA4_CREDENTIALS  - service account JSON key (client_email, private_key)
+//   GA4_PROPERTY_ID  - numeric GA4 property id
+import fs from 'fs';
+import { createSign } from 'crypto';
+
+const creds = JSON.parse(process.env.GA4_CREDENTIALS);
+const property = process.env.GA4_PROPERTY_ID;
+if (!creds.client_email || !creds.private_key || !property) {
+    console.error('GA4_CREDENTIALS and GA4_PROPERTY_ID must be set');
+    process.exit(1);
+}
+
+const b64url = s => Buffer.from(s).toString('base64url');
+
+async function getAccessToken() {
+    const now = Math.floor(Date.now() / 1000);
+    const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+    const claims = b64url(JSON.stringify({
+        iss: creds.client_email,
+        scope: 'https://www.googleapis.com/auth/analytics.readonly',
+        aud: 'https://oauth2.googleapis.com/token',
+        iat: now,
+        exp: now + 3600,
+    }));
+    const signer = createSign('RSA-SHA256');
+    signer.update(`${header}.${claims}`);
+    const jwt = `${header}.${claims}.${signer.sign(creds.private_key).toString('base64url')}`;
+
+    const res = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            assertion: jwt,
+        }),
+    });
+    if (!res.ok) throw new Error(`token exchange failed: ${res.status} ${await res.text()}`);
+    return (await res.json()).access_token;
+}
+
+async function runReport(token, body) {
+    const res = await fetch(
+        `https://analyticsdata.googleapis.com/v1beta/properties/${property}:runReport`,
+        {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        }
+    );
+    if (!res.ok) throw new Error(`runReport failed: ${res.status} ${await res.text()}`);
+    return res.json();
+}
+
+const token = await getAccessToken();
+console.log('✅ token exchange OK');
+
+// Daily visitors and pageviews, last 30 days
+const daily = await runReport(token, {
+    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+    dimensions: [{ name: 'date' }],
+    metrics: [{ name: 'activeUsers' }, { name: 'screenPageViews' }],
+    orderBys: [{ dimension: { dimensionName: 'date' } }],
+});
+console.log(`✅ daily report: ${daily.rows?.length ?? 0} rows`);
+
+// Most-clicked links, last 30 days. Requires the link_title/link_category
+// custom dimensions; tolerate absence so the pull works before they exist.
+let clicks = { rows: [] };
+try {
+    clicks = await runReport(token, {
+        dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+        dimensions: [{ name: 'customEvent:link_title' }, { name: 'customEvent:link_category' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+            filter: { fieldName: 'eventName', stringFilter: { value: 'link_click' } },
+        },
+        orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+        limit: 50,
+    });
+    console.log(`✅ link_click report: ${clicks.rows?.length ?? 0} rows`);
+} catch (e) {
+    console.log(`⚠️  link_click report unavailable (custom dimensions not registered yet?): ${e.message}`);
+}
+
+const analytics = {
+    generated: new Date().toISOString(),
+    rangeDays: 30,
+    daily: (daily.rows ?? []).map(r => ({
+        date: r.dimensionValues[0].value,
+        users: Number(r.metricValues[0].value),
+        pageviews: Number(r.metricValues[1].value),
+    })),
+    topLinks: (clicks.rows ?? []).map(r => ({
+        title: r.dimensionValues[0].value,
+        category: r.dimensionValues[1].value,
+        clicks: Number(r.metricValues[0].value),
+    })),
+};
+analytics.totals = {
+    users: analytics.daily.reduce((s, d) => s + d.users, 0),
+    pageviews: analytics.daily.reduce((s, d) => s + d.pageviews, 0),
+    linkClicks: analytics.topLinks.reduce((s, l) => s + l.clicks, 0),
+};
+
+fs.writeFileSync('src/analytics.json', JSON.stringify(analytics, null, 2) + '\n');
+console.log(`✅ wrote src/analytics.json — ${analytics.totals.users} users, ` +
+    `${analytics.totals.pageviews} pageviews, ${analytics.topLinks.length} ranked links`);

--- a/scripts/fetch-analytics.js
+++ b/scripts/fetch-analytics.js
@@ -4,6 +4,11 @@
 // dependencies. Requires env vars:
 //   GA4_CREDENTIALS  - service account JSON key (client_email, private_key)
 //   GA4_PROPERTY_ID  - numeric GA4 property id
+//
+// Output shape:
+//   daily:  365 days of {date, users, pageviews} for the trend chart
+//   ranges: per preset (30/90/365 days) totals, top links, and category
+//           breakdown from link_click events
 import fs from 'fs';
 import { createSign } from 'crypto';
 
@@ -14,6 +19,7 @@ if (!creds.client_email || !creds.private_key || !property) {
     process.exit(1);
 }
 
+const RANGES = [30, 90, 365];
 const b64url = s => Buffer.from(s).toString('base64url');
 
 async function getAccessToken() {
@@ -55,57 +61,80 @@ async function runReport(token, body) {
     return res.json();
 }
 
+const linkClickFilter = {
+    filter: { fieldName: 'eventName', stringFilter: { value: 'link_click' } },
+};
+
 const token = await getAccessToken();
 console.log('✅ token exchange OK');
 
-// Daily visitors and pageviews, last 30 days
-const daily = await runReport(token, {
-    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+// Daily visitors and pageviews for the full year
+const dailyReport = await runReport(token, {
+    dateRanges: [{ startDate: '365daysAgo', endDate: 'today' }],
     dimensions: [{ name: 'date' }],
     metrics: [{ name: 'activeUsers' }, { name: 'screenPageViews' }],
     orderBys: [{ dimension: { dimensionName: 'date' } }],
+    limit: 400,
 });
-console.log(`✅ daily report: ${daily.rows?.length ?? 0} rows`);
+console.log(`✅ daily report: ${dailyReport.rows?.length ?? 0} rows`);
 
-// Most-clicked links, last 30 days. Requires the link_title/link_category
-// custom dimensions; tolerate absence so the pull works before they exist.
-let clicks = { rows: [] };
-try {
-    clicks = await runReport(token, {
-        dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
-        dimensions: [{ name: 'customEvent:link_title' }, { name: 'customEvent:link_category' }],
-        metrics: [{ name: 'eventCount' }],
-        dimensionFilter: {
-            filter: { fieldName: 'eventName', stringFilter: { value: 'link_click' } },
+const daily = (dailyReport.rows ?? []).map(r => ({
+    date: r.dimensionValues[0].value,
+    users: Number(r.metricValues[0].value),
+    pageviews: Number(r.metricValues[1].value),
+}));
+
+// Per-preset link_click reports. Tolerate missing custom dimensions so the
+// pull works before they are registered / collecting.
+const ranges = {};
+for (const days of RANGES) {
+    const dateRanges = [{ startDate: `${days}daysAgo`, endDate: 'today' }];
+    let topLinks = [];
+    let categories = [];
+    try {
+        const links = await runReport(token, {
+            dateRanges,
+            dimensions: [{ name: 'customEvent:link_title' }, { name: 'customEvent:link_category' }],
+            metrics: [{ name: 'eventCount' }],
+            dimensionFilter: linkClickFilter,
+            orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+            limit: 25,
+        });
+        topLinks = (links.rows ?? []).map(r => ({
+            title: r.dimensionValues[0].value,
+            category: r.dimensionValues[1].value,
+            clicks: Number(r.metricValues[0].value),
+        }));
+        const cats = await runReport(token, {
+            dateRanges,
+            dimensions: [{ name: 'customEvent:link_category' }],
+            metrics: [{ name: 'eventCount' }],
+            dimensionFilter: linkClickFilter,
+            orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+            limit: 30,
+        });
+        categories = (cats.rows ?? []).map(r => ({
+            category: r.dimensionValues[0].value,
+            clicks: Number(r.metricValues[0].value),
+        }));
+        console.log(`✅ link_click reports (${days}d): ${topLinks.length} links, ${categories.length} categories`);
+    } catch (e) {
+        console.log(`⚠️  link_click reports unavailable for ${days}d (custom dimensions not registered yet?): ${e.message}`);
+    }
+
+    const window = daily.slice(-days);
+    ranges[days] = {
+        totals: {
+            users: window.reduce((s, d) => s + d.users, 0),
+            pageviews: window.reduce((s, d) => s + d.pageviews, 0),
+            linkClicks: categories.reduce((s, c) => s + c.clicks, 0),
         },
-        orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
-        limit: 50,
-    });
-    console.log(`✅ link_click report: ${clicks.rows?.length ?? 0} rows`);
-} catch (e) {
-    console.log(`⚠️  link_click report unavailable (custom dimensions not registered yet?): ${e.message}`);
+        topLinks,
+        categories,
+    };
 }
 
-const analytics = {
-    generated: new Date().toISOString(),
-    rangeDays: 30,
-    daily: (daily.rows ?? []).map(r => ({
-        date: r.dimensionValues[0].value,
-        users: Number(r.metricValues[0].value),
-        pageviews: Number(r.metricValues[1].value),
-    })),
-    topLinks: (clicks.rows ?? []).map(r => ({
-        title: r.dimensionValues[0].value,
-        category: r.dimensionValues[1].value,
-        clicks: Number(r.metricValues[0].value),
-    })),
-};
-analytics.totals = {
-    users: analytics.daily.reduce((s, d) => s + d.users, 0),
-    pageviews: analytics.daily.reduce((s, d) => s + d.pageviews, 0),
-    linkClicks: analytics.topLinks.reduce((s, l) => s + l.clicks, 0),
-};
-
+const analytics = { generated: new Date().toISOString(), daily, ranges };
 fs.writeFileSync('src/analytics.json', JSON.stringify(analytics, null, 2) + '\n');
-console.log(`✅ wrote src/analytics.json — ${analytics.totals.users} users, ` +
-    `${analytics.totals.pageviews} pageviews, ${analytics.topLinks.length} ranked links`);
+console.log(`✅ wrote src/analytics.json — ${daily.length} daily rows, ` +
+    RANGES.map(d => `${d}d: ${ranges[d].totals.users} users`).join(', '));

--- a/src/analytics.pug
+++ b/src/analytics.pug
@@ -24,60 +24,61 @@ html.bg-spice-brown(lang='en')
     .container
       .offcenter
         h2 Usage
-        em.d-none.d-md-block Updated #{analytics_date}
+        em.d-none.d-md-block(title=analytics_utc) Updated #{analytics_date}
 
       .btn-group.mb-3#range-presets(hidden role='group' aria-label='Date range')
         button.btn.btn-sm.btn-outline-dark.active(type='button' data-range='30') 30 days
         button.btn.btn-sm.btn-outline-dark(type='button' data-range='90') 90 days
         button.btn.btn-sm.btn-outline-dark(type='button' data-range='365') 1 year
 
-      .row.g-3.justify-content-center
-        .col-4.col-lg-3
-          .card.stat-tile
-            .num#stat-users #{fmtNum(r30.totals.users)}
-            .lbl Visitors
-        .col-4.col-lg-3
-          .card.stat-tile
-            .num#stat-pageviews #{fmtNum(r30.totals.pageviews)}
-            .lbl Pageviews
-        .col-4.col-lg-3
-          .card.stat-tile
-            .num#stat-clicks #{fmtNum(r30.totals.linkClicks)}
-            .lbl Link clicks
+      .usage-stack
+        .row.g-3
+          .col-4
+            .card.stat-tile
+              .num#stat-users #{fmtNum(r30.totals.users)}
+              .lbl Visitors
+          .col-4
+            .card.stat-tile
+              .num#stat-pageviews #{fmtNum(r30.totals.pageviews)}
+              .lbl Pageviews
+          .col-4
+            .card.stat-tile
+              .num#stat-clicks #{fmtNum(r30.totals.linkClicks)}
+              .lbl Link clicks
 
-      .card.chart-card.mt-3
-        .chart-title#trend-title Daily visitors
-        .trend#trend-chart
-          each d, i in d30
-            i(class=(i === maxIdx ? 'hi' : '') style=`height:${Math.max(2, Math.round(d.users / maxUsers * 100))}%` title=`${fmtDate(d.date)}: ${fmtNum(d.users)}`)
-        .axis#trend-axis
-          span #{d30.length ? fmtDate(d30[0].date) : ''}
-          span #{d30.length ? fmtDate(d30[d30.length - 1].date) : ''}
+        .card.chart-card.mt-3
+          .chart-title#trend-title Daily visitors
+          .trend#trend-chart
+            each d, i in d30
+              i(class=(i === maxIdx ? 'hi' : '') style=`height:${Math.max(2, Math.round(d.users / maxUsers * 100))}%` title=`${fmtDate(d.date)}: ${fmtNum(d.users)}${i === maxIdx ? ' (busiest day)' : ''}`)
+          .axis#trend-axis
+            span #{d30.length ? fmtDate(d30[0].date) : ''}
+            span #{d30.length ? fmtDate(d30[d30.length - 1].date) : ''}
 
-      .card.chart-card.mt-3
-        .chart-title Most-clicked links
-        if r30.topLinks.length
-          .rank#rank-links
-            each l in r30.topLinks.slice(0, 10)
-              .r
-                span.t #{l.title}
-                  span.cat #{l.category}
-                span.bar(style=`width:${Math.max(2, Math.round(l.clicks / maxLink * 100))}%`)
-                span.n #{fmtNum(l.clicks)}
-        else
-          p.small.text-muted.mb-0#rank-links No click data collected yet.
+        .card.chart-card.mt-3
+          .chart-title Most-clicked links
+          if r30.topLinks.length
+            .rank#rank-links
+              each l in r30.topLinks.slice(0, 10)
+                .r
+                  span.t #{l.title}
+                    span.cat #{l.category}
+                  span.bar(style=`width:${Math.max(2, Math.round(l.clicks / maxLink * 100))}%`)
+                  span.n #{fmtNum(l.clicks)}
+          else
+            p.small.text-muted.mb-0#rank-links No click data collected yet.
 
-      .card.chart-card.mt-3.mb-1
-        .chart-title Clicks by category
-        if r30.categories.length
-          .rank#rank-cats
-            each c in r30.categories
-              .r
-                span.t #{c.category}
-                span.bar(style=`width:${Math.max(2, Math.round(c.clicks / maxCat * 100))}%`)
-                span.n #{fmtNum(c.clicks)}
-        else
-          p.small.text-muted.mb-0#rank-cats No click data collected yet.
+        .card.chart-card.mt-3.mb-1
+          .chart-title Clicks by category
+          if r30.categories.length
+            .rank#rank-cats
+              each c in r30.categories
+                .r
+                  span.t #{c.category}
+                  span.bar(style=`width:${Math.max(2, Math.round(c.clicks / maxCat * 100))}%`)
+                  span.n #{fmtNum(c.clicks)}
+          else
+            p.small.text-muted.mb-0#rank-cats No click data collected yet.
 
   section#footer.bg-spice-brown.py-1.text-end
     .container

--- a/src/analytics.pug
+++ b/src/analytics.pug
@@ -1,0 +1,93 @@
+doctype html
+html.bg-spice-brown(lang='en')
+
+  include includes/head.pug
+
+  //- Navigation
+  +navigation
+    a.nav-link(href='/overrides') Overrides
+    a.nav-link(href='/tutorial') Tutorial
+
+  //- Server-rendered 30-day view; the preset buttons are hidden until the
+  //- client script takes over and re-renders from the embedded JSON.
+  - var r30 = analytics.ranges['30']
+  - var d30 = analytics.daily.slice(-30)
+  - var maxUsers = Math.max.apply(null, d30.map(d => d.users).concat([1]))
+  - var maxIdx = d30.map(d => d.users).indexOf(maxUsers)
+  - var maxLink = r30.topLinks.length ? r30.topLinks[0].clicks : 1
+  - var maxCat = r30.categories.length ? r30.categories[0].clicks : 1
+  - var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+  - var fmtDate = s => Number(s.slice(6,8)) + ' ' + months[Number(s.slice(4,6)) - 1]
+  - var fmtNum = n => n.toLocaleString('en-US')
+
+  section#usage.bg-sage.text-center
+    .container
+      .offcenter
+        h2 Usage
+        em.d-none.d-md-block Updated #{analytics_date}
+
+      .btn-group.mb-3#range-presets(hidden role='group' aria-label='Date range')
+        button.btn.btn-sm.btn-outline-dark.active(type='button' data-range='30') 30 days
+        button.btn.btn-sm.btn-outline-dark(type='button' data-range='90') 90 days
+        button.btn.btn-sm.btn-outline-dark(type='button' data-range='365') 1 year
+
+      .row.g-3.justify-content-center
+        .col-4.col-lg-3
+          .card.stat-tile
+            .num#stat-users #{fmtNum(r30.totals.users)}
+            .lbl Visitors
+        .col-4.col-lg-3
+          .card.stat-tile
+            .num#stat-pageviews #{fmtNum(r30.totals.pageviews)}
+            .lbl Pageviews
+        .col-4.col-lg-3
+          .card.stat-tile
+            .num#stat-clicks #{fmtNum(r30.totals.linkClicks)}
+            .lbl Link clicks
+
+      .card.chart-card.mt-3
+        .chart-title#trend-title Daily visitors
+        .trend#trend-chart
+          each d, i in d30
+            i(class=(i === maxIdx ? 'hi' : '') style=`height:${Math.max(2, Math.round(d.users / maxUsers * 100))}%` title=`${fmtDate(d.date)}: ${fmtNum(d.users)}`)
+        .axis#trend-axis
+          span #{d30.length ? fmtDate(d30[0].date) : ''}
+          span #{d30.length ? fmtDate(d30[d30.length - 1].date) : ''}
+
+      .card.chart-card.mt-3
+        .chart-title Most-clicked links
+        if r30.topLinks.length
+          .rank#rank-links
+            each l in r30.topLinks.slice(0, 10)
+              .r
+                span.t #{l.title}
+                  span.cat #{l.category}
+                span.bar(style=`width:${Math.max(2, Math.round(l.clicks / maxLink * 100))}%`)
+                span.n #{fmtNum(l.clicks)}
+        else
+          p.small.text-muted.mb-0#rank-links No click data collected yet.
+
+      .card.chart-card.mt-3.mb-1
+        .chart-title Clicks by category
+        if r30.categories.length
+          .rank#rank-cats
+            each c in r30.categories
+              .r
+                span.t #{c.category}
+                span.bar(style=`width:${Math.max(2, Math.round(c.clicks / maxCat * 100))}%`)
+                span.n #{fmtNum(c.clicks)}
+        else
+          p.small.text-muted.mb-0#rank-cats No click data collected yet.
+
+  section#footer.bg-spice-brown.py-1.text-end
+    .container
+      em Anonymized aggregates from Google Analytics, refreshed nightly.
+
+  script#analytics-data(type='application/json') !{JSON.stringify(analytics).replace(/</g, '\\u003c')}
+  script
+    if isDev
+      include includes/js/analytics.js
+    else
+      include:uglify-js includes/js/analytics.js
+
+  include includes/foot.pug

--- a/src/announcements.json
+++ b/src/announcements.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Hey!",
+    "body": "Click here to learn how to search aflink from your browser address bar",
+    "link": "/tutorial"
+  },
+  {
+    "title": "New!",
+    "body": "See what links people actually use — 30-day, 90-day, and 1-year stats on the new Usage page",
+    "link": "/analytics",
+    "start": "2026-08-04",
+    "end": "2026-11-04"
+  }
+]

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -177,6 +177,115 @@ section[id] {
   }
 }
 
+/* Analytics page: stat tiles, column trend, horizontal ranking bars.
+   Single-series charts in steel blue with a Cannes-blue peak accent. */
+.stat-tile {
+  padding: 0.8rem 0.5rem;
+  border: 0;
+}
+
+.stat-tile .num {
+  font-size: 1.55rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  color: #212529;
+}
+
+.stat-tile .lbl {
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c757d;
+}
+
+.chart-card {
+  padding: 0.9rem 1rem;
+  border: 0;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.chart-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #212529;
+  margin-bottom: 0.5rem;
+  text-align: left;
+}
+
+.trend {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 88px;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.trend i {
+  flex: 1;
+  background: #4F7396;
+  border-radius: 3px 3px 0 0;
+  min-width: 2px;
+}
+
+.trend i.hi {
+  background: #7BAFD4;
+}
+
+.axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: #6c757d;
+  margin-top: 0.25rem;
+}
+
+.rank {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.rank .r {
+  display: grid;
+  grid-template-columns: 1fr 3.2rem;
+  align-items: center;
+  gap: 0 0.6rem;
+}
+
+.rank .t {
+  grid-column: 1;
+  font-size: 0.82rem;
+  color: #212529;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.rank .cat {
+  font-size: 0.68rem;
+  color: #6c757d;
+  margin-left: 0.4rem;
+}
+
+.rank .bar {
+  grid-column: 1;
+  height: 8px;
+  border-radius: 4px;
+  background: #4F7396;
+  margin-top: 2px;
+}
+
+.rank .n {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  font-size: 0.8rem;
+  color: #212529;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
 /* Overrides page: truncate long URLs to fit; the full link shows on hover
    via the title attribute */
 .link-container .col {

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -198,12 +198,14 @@ section[id] {
   color: #6c757d;
 }
 
+.usage-stack {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
 .chart-card {
   padding: 0.9rem 1rem;
   border: 0;
-  max-width: 640px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .chart-title {

--- a/src/includes/js/analytics.js
+++ b/src/includes/js/analytics.js
@@ -41,7 +41,8 @@
       var col = document.createElement('i');
       if (i === maxIdx) col.className = 'hi';
       col.style.height = Math.max(2, Math.round(b.users / max * 100)) + '%';
-      col.title = (bucket > 1 ? 'week of ' : '') + fmtDate(b.date) + ': ' + fmtNum(b.users);
+      col.title = (bucket > 1 ? 'week of ' : '') + fmtDate(b.date) + ': ' + fmtNum(b.users) +
+        (i === maxIdx ? (bucket > 1 ? ' (busiest week)' : ' (busiest day)') : '');
       chart.appendChild(col);
     });
 

--- a/src/includes/js/analytics.js
+++ b/src/includes/js/analytics.js
@@ -1,0 +1,114 @@
+// Progressive enhancement for /analytics: the build ships a static 30-day
+// view; this script unhides the range presets and re-renders the tiles and
+// charts from the embedded JSON when a preset is chosen.
+(function () {
+  var dataEl = document.getElementById('analytics-data');
+  var presets = document.getElementById('range-presets');
+  if (!dataEl || !presets) return;
+
+  var data;
+  try {
+    data = JSON.parse(dataEl.textContent);
+  } catch (e) {
+    return; // leave the server-rendered view alone
+  }
+
+  var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  function fmtDate(s) { return Number(s.slice(6, 8)) + ' ' + MONTHS[Number(s.slice(4, 6)) - 1]; }
+  function fmtNum(n) { return n.toLocaleString('en-US'); }
+
+  function setText(id, text) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = text;
+  }
+
+  function renderTrend(days) {
+    var window = data.daily.slice(-days);
+    // Bucket long ranges so the chart keeps readable column widths
+    var bucket = days > 120 ? 7 : 1;
+    var buckets = [];
+    for (var i = 0; i < window.length; i += bucket) {
+      var users = 0;
+      for (var j = i; j < Math.min(i + bucket, window.length); j++) users += window[j].users;
+      buckets.push({ users: users, date: window[i].date });
+    }
+    var max = 1, maxIdx = 0;
+    buckets.forEach(function (b, i) { if (b.users > max) { max = b.users; maxIdx = i; } });
+
+    var chart = document.getElementById('trend-chart');
+    chart.innerHTML = '';
+    buckets.forEach(function (b, i) {
+      var col = document.createElement('i');
+      if (i === maxIdx) col.className = 'hi';
+      col.style.height = Math.max(2, Math.round(b.users / max * 100)) + '%';
+      col.title = (bucket > 1 ? 'week of ' : '') + fmtDate(b.date) + ': ' + fmtNum(b.users);
+      chart.appendChild(col);
+    });
+
+    setText('trend-title', bucket > 1 ? 'Weekly visitors' : 'Daily visitors');
+    var axis = document.getElementById('trend-axis');
+    if (axis && window.length) {
+      axis.innerHTML = '';
+      [window[0].date, window[window.length - 1].date].forEach(function (d) {
+        var s = document.createElement('span');
+        s.textContent = fmtDate(d);
+        axis.appendChild(s);
+      });
+    }
+  }
+
+  function renderRank(id, rows, labelKey, withCategory) {
+    var host = document.getElementById(id);
+    if (!host) return;
+    if (!rows.length) {
+      host.textContent = 'No click data collected yet.';
+      return;
+    }
+    var max = rows[0].clicks || 1;
+    var wrap = document.createElement('div');
+    wrap.className = 'rank';
+    wrap.id = id;
+    rows.forEach(function (row) {
+      var r = document.createElement('div');
+      r.className = 'r';
+      var t = document.createElement('span');
+      t.className = 't';
+      t.textContent = row[labelKey];
+      if (withCategory && row.category) {
+        var c = document.createElement('span');
+        c.className = 'cat';
+        c.textContent = row.category;
+        t.appendChild(c);
+      }
+      var bar = document.createElement('span');
+      bar.className = 'bar';
+      bar.style.width = Math.max(2, Math.round(row.clicks / max * 100)) + '%';
+      var n = document.createElement('span');
+      n.className = 'n';
+      n.textContent = fmtNum(row.clicks);
+      r.appendChild(t); r.appendChild(bar); r.appendChild(n);
+      wrap.appendChild(r);
+    });
+    host.replaceWith(wrap);
+  }
+
+  function render(days) {
+    var r = data.ranges[String(days)];
+    if (!r) return;
+    setText('stat-users', fmtNum(r.totals.users));
+    setText('stat-pageviews', fmtNum(r.totals.pageviews));
+    setText('stat-clicks', fmtNum(r.totals.linkClicks));
+    renderTrend(days);
+    renderRank('rank-links', r.topLinks.slice(0, 10), 'title', true);
+    renderRank('rank-cats', r.categories, 'category', false);
+  }
+
+  presets.hidden = false;
+  presets.addEventListener('click', function (e) {
+    var btn = e.target.closest('button[data-range]');
+    if (!btn) return;
+    presets.querySelectorAll('button').forEach(function (b) { b.classList.remove('active'); });
+    btn.classList.add('active');
+    render(Number(btn.getAttribute('data-range')));
+  });
+})();

--- a/src/includes/js/search.js
+++ b/src/includes/js/search.js
@@ -23,6 +23,18 @@ $(document).ready(function () {
   $("#link-list .list-group-item a:first-child, #unofficial-list .list-group-item a:first-child").on('click', function(event) {
     $('#exit-modal .modal-header .title').text($(this).text());
     $('#exit-modal .link').text($(this).prop('href'));
+
+    // Record which link was used so the analytics page can rank resources.
+    // Anonymous event; gtag delivers via sendBeacon so navigation isn't delayed.
+    if (typeof gtag === 'function') {
+      var $cat = $(this).closest('.link-container').siblings('.category');
+      gtag('event', 'link_click', {
+        link_title: $(this).text(),
+        link_url: this.href,
+        link_category: $cat.length ? ($cat.data('orig-text') || $cat.text()) : 'UNOFFICIAL'
+      });
+    }
+
     my_modal.toggle();
   });
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -11,17 +11,30 @@ html.bg-spice-brown(lang='en')
     a.nav-link(href='#about') About
     span.nav-separator.d-none.d-lg-inline= '|'
     a.nav-link(href='#update') Update Links
+    if hasAnalytics
+      span.nav-separator.d-none.d-lg-inline= '|'
+      a.nav-link(href='/analytics') Usage
     span.nav-separator.d-none.d-lg-inline= '|'
     a.nav-link(href='/tutorial') Tutorial
 
 
   //- Page Content
-  section#alert.bg-sage.text-center
-    a.no-dec(href='/tutorial')
-      .container.alert.alert-primary.bg-cannes-blue.no-border(role='alert')
-        strong Hey! 
-        |
-        | Click here to learn how to search aflink from your browser address bar 
+  //- Announcements: data-driven from src/announcements.json, filtered to the
+  //- build-time active window in updater.js
+  if announcements.length
+    section#alert.bg-sage.text-center
+      each item in announcements
+        if item.link
+          a.no-dec(href=item.link)
+            .container.alert.alert-primary.bg-cannes-blue.no-border.mb-2(role='alert')
+              strong #{item.title}
+              |
+              | #{item.body}
+        else
+          .container.alert.alert-primary.bg-cannes-blue.no-border.mb-2(role='alert')
+            strong #{item.title}
+            |
+            | #{item.body}
   section#search.bg-sage.text-center
     .container
       .form-outline

--- a/src/index.pug
+++ b/src/index.pug
@@ -71,8 +71,10 @@ html.bg-spice-brown(lang='en')
   section#footer.bg-spice-brown.py-1
     .row
       .col
-        .text-start 
+        .text-start.d-flex.gap-3
           a.nav-link(href='/overrides') Overrides
+          if hasAnalytics
+            a.nav-link(href='/analytics') Usage
       .col
         .text-end
           em

--- a/updater.js
+++ b/updater.js
@@ -314,6 +314,7 @@ async function getNewestDate(files) {
                 ...options,
                 analytics,
                 analytics_date: sugar_date.Date.format(new Date(analytics.generated), '{d} {Month} {yyyy}'),
+                analytics_utc: new Date(analytics.generated).toISOString().replace('T', ' ').slice(0, 16) + ' UTC',
                 isDev: environment !== 'production'
             })
             const analyticsDir = path.resolve(outputDir, "analytics")

--- a/updater.js
+++ b/updater.js
@@ -267,11 +267,19 @@ async function getNewestDate(files) {
         }
 
         // write homepage
+        // Analytics data exists only after the nightly workflow's first commit;
+        // until then the page and its footer link are simply omitted.
+        const analyticsPath = path.resolve(srcDir, 'analytics.json')
+        const analytics = fs.existsSync(analyticsPath)
+            ? JSON.parse(fs.readFileSync(analyticsPath))
+            : null;
+
         const pageHome = pug.renderFile(path.resolve(srcDir, "index.pug"), {
             ...options,
             links,
             unofficial: links_unofficial,
             date,
+            hasAnalytics: !!analytics,
             isDev: environment !== 'production'
         })
         fs.writeFileSync(path.resolve(outputDir, "index.html"), pageHome)
@@ -299,6 +307,20 @@ async function getNewestDate(files) {
         fs.mkdirSync(overridesDir, { recursive: true });
         fs.writeFileSync(path.resolve(overridesDir, "index.html"), pageOverrides)
         console.log("Wrote overrides page")
+
+        // write analytics page (only when the nightly pull has produced data)
+        if (analytics) {
+            const pageAnalytics = pug.renderFile(path.resolve(srcDir, "analytics.pug"), {
+                ...options,
+                analytics,
+                analytics_date: sugar_date.Date.format(new Date(analytics.generated), '{d} {Month} {yyyy}'),
+                isDev: environment !== 'production'
+            })
+            const analyticsDir = path.resolve(outputDir, "analytics")
+            fs.mkdirSync(analyticsDir, { recursive: true });
+            fs.writeFileSync(path.resolve(analyticsDir, "index.html"), pageAnalytics)
+            console.log("Wrote analytics page")
+        }
 
         // write osdd.xml
         const osdd = pug.renderFile(path.resolve(srcDir, "osdd.xml.pug"), { ...options, ...locals })

--- a/updater.js
+++ b/updater.js
@@ -267,6 +267,17 @@ async function getNewestDate(files) {
         }
 
         // write homepage
+        // Announcements active at build time. start/end are optional; no end
+        // means permanent. The nightly analytics build doubles as the clock
+        // that brings date-windowed announcements up and takes them down.
+        const announcementsPath = path.resolve(srcDir, 'announcements.json')
+        const buildNow = Date.now()
+        const announcements = (fs.existsSync(announcementsPath)
+            ? JSON.parse(fs.readFileSync(announcementsPath))
+            : []).filter(a =>
+                (!a.start || new Date(a.start).getTime() <= buildNow) &&
+                (!a.end || buildNow <= new Date(a.end).getTime()));
+
         // Analytics data exists only after the nightly workflow's first commit;
         // until then the page and its footer link are simply omitted.
         const analyticsPath = path.resolve(srcDir, 'analytics.json')
@@ -280,6 +291,7 @@ async function getNewestDate(files) {
             unofficial: links_unofficial,
             date,
             hasAnalytics: !!analytics,
+            announcements,
             isDev: environment !== 'production'
         })
         fs.writeFileSync(path.resolve(outputDir, "index.html"), pageHome)


### PR DESCRIPTION
Completes the final item from #51 (usage analytics dashboard) and adds a general-purpose
announcements system that rides on the same nightly build.

## What's included

### Click tracking
- Link clicks fire an anonymous GA4 `link_click` event (title, URL, category) from the existing
  exit-modal handler. Delivery is via sendBeacon so navigation is never delayed; no-ops when
  gtag is blocked or absent. GA4 previously only recorded page views, so "most-clicked
  resources" had no data source — collection starts when this deploys.

### Nightly GA4 pull (`.github/workflows/analytics.yml` + `scripts/fetch-analytics.js`)
- Runs daily at 09:17 UTC (plus `workflow_dispatch` for manual runs). Fetches 365 days of
  daily visitors/pageviews and per-preset (30/90/365-day) link rankings and category
  breakdowns, writes `src/analytics.json`, commits, and triggers the site build.
- Dependency-free Data API client: the service-account JWT is signed with Node's built-in
  crypto and reports are fetched over REST — no npm packages.
- Tolerates unregistered custom dimensions (logs a warning, writes empty rankings) so the
  pull works during staged rollout.

### /analytics page
- Server-rendered 30-day view in plain HTML/CSS: stat tiles (visitors, pageviews, link
  clicks), a daily-visitors column chart with the busiest day accented in Cannes blue,
  the most-clicked top 10, and a clicks-by-category card. Fully readable with no JS.
- With JS: 30 days / 90 days / 1 year preset buttons appear and re-render everything from
  embedded JSON (~100 lines of vanilla DOM code, no chart library). The 1-year trend buckets
  into weeks to keep columns readable.
- "Updated" shows the last data refresh; hover gives the full UTC timestamp.
- The page, the navbar Usage link, and the footer Usage link are all omitted until the
  workflow commits `analytics.json` for the first time — merging before the first run is safe.

### Announcements
- `src/announcements.json`: list of `{title, body, start?, end?, link?}`. The build filters to
  entries whose window contains build time; no end date means permanent. Since the nightly
  analytics run rebuilds the site daily, date-windowed announcements raise and expire
  themselves within a day of their dates.
- The hardcoded tutorial alert is migrated to the permanent first entry; a second entry
  advertises the Usage page through 4 November 2026.

## Setup already completed (documented for posterity)
- GA4 event-scoped custom dimensions registered: `link_title`, `link_url`, `link_category`.
- Google Cloud service account with the Analytics Data API enabled, granted **Viewer** on the
  GA4 property (no project-level IAM roles).
- Repository secrets: `GA4_CREDENTIALS` (service-account JSON key), `GA4_PROPERTY_ID`.

## Testing
- Page verified locally against sample data (dev build + serve): no-JS 30-day rendering,
  preset switching, weekly bucketing, tooltips, announcement windowing, nav/footer gating.
- Post-merge: run the "Analytics Pull" workflow manually on master once to exercise the full
  chain (pull → commit → build → deploy), then confirm tonight's scheduled run appears in
  Actions. First days after merge will show real pageview history but near-zero click counts
  while collection ramps — expected.

## Notes
- Scheduled workflows only run from the default branch, which is why the cron is untestable
  pre-merge.
- GitHub auto-disables schedules after 60 days of repo inactivity; this repo's issue-driven
  commits make that unlikely, but it's the known silent-failure mode if the nightly ever stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
