### PR TITLE
Gate range presets on actual data span; add gathering note; Usage ann…

### DIFF
--- a/src/analytics.pug
+++ b/src/analytics.pug
@@ -19,6 +19,12 @@ html.bg-spice-brown(lang='en')
   - var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
   - var fmtDate = s => Number(s.slice(6,8)) + ' ' + months[Number(s.slice(4,6)) - 1]
   - var fmtNum = n => n.toLocaleString('en-US')
+  //- How far back the data actually reaches decides which presets exist
+  - var earliest = analytics.daily.length ? analytics.daily[0].date : null
+  - var spanDays = earliest ? Math.round((new Date(analytics.generated) - new Date(earliest.slice(0,4) + '-' + earliest.slice(4,6) + '-' + earliest.slice(6,8))) / 86400000) : 0
+  //- 350 rather than 365: date arithmetic across the window is ±1-2 days, and
+  //- "nearly a year" is close enough to stop calling the data incomplete
+  - var gathering = spanDays < 350 || !analytics.ranges['365'].totals.linkClicks
 
   section#usage.bg-sage.text-center
     .container
@@ -26,10 +32,15 @@ html.bg-spice-brown(lang='en')
         h2 Usage
         em.d-none.d-md-block(title=analytics_utc) Updated #{analytics_date}
 
+      if gathering
+        p.small.fst-italic.mb-2 Usage data is still being gathered — longer ranges unlock as history accumulates.
+
       .btn-group.mb-3#range-presets(hidden role='group' aria-label='Date range')
         button.btn.btn-sm.btn-outline-dark.active(type='button' data-range='30') 30 days
-        button.btn.btn-sm.btn-outline-dark(type='button' data-range='90') 90 days
-        button.btn.btn-sm.btn-outline-dark(type='button' data-range='365') 1 year
+        if spanDays > 30
+          button.btn.btn-sm.btn-outline-dark(type='button' data-range='90') 90 days
+        if spanDays > 90
+          button.btn.btn-sm.btn-outline-dark(type='button' data-range='365') 1 year
 
       .usage-stack
         .row.g-3

--- a/src/announcements.json
+++ b/src/announcements.json
@@ -8,7 +8,7 @@
     "title": "New!",
     "body": "See what links people actually use — 30-day, 90-day, and 1-year stats on the new Usage page",
     "link": "/analytics",
-    "start": "2026-08-04",
-    "end": "2026-11-04"
+    "start": "2026-08-03",
+    "end": "2027-02-03"
   }
 ]

--- a/src/includes/js/analytics.js
+++ b/src/includes/js/analytics.js
@@ -104,7 +104,11 @@
     renderRank('rank-cats', r.categories, 'category', false);
   }
 
-  presets.hidden = false;
+  // The build renders only the presets the data span supports; with a single
+  // option there is nothing to switch, so the group stays hidden
+  if (presets.querySelectorAll('button[data-range]').length > 1) {
+    presets.hidden = false;
+  }
   presets.addEventListener('click', function (e) {
     var btn = e.target.closest('button[data-range]');
     if (!btn) return;


### PR DESCRIPTION
…ouncement

Presets render only when the data reaches back far enough (90d needs
>30 days of history, 1y needs >90); with a single option the group
stays hidden. A note explains data is still being gathered until history spans ~a year and click data exists. The Usage announcement runs six months, 3 Aug 2026 through 3 Feb 2027.