### PR TITLE
Import quality, clearer sync date, and Pushover staleness reminder

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_link_delete.yaml
+++ b/.github/ISSUE_TEMPLATE/03_link_delete.yaml
@@ -13,6 +13,20 @@ body:
       placeholder: 037a5a53-db87-48f5-8c6e-017d65bf8b3c
     validations:
       required: true
+  - type: input
+    id: current_title
+    attributes:
+      label: 🔒 Current Link Title
+      description: "Auto-filled for reference. Edits to this field are ignored."
+    validations:
+      required: false
+  - type: input
+    id: current_url
+    attributes:
+      label: 🔒 Current Link URL
+      description: "Auto-filled for reference. Edits to this field are ignored."
+    validations:
+      required: false
   - type: textarea
     id: comment
     attributes:

--- a/.github/workflows/af_sync_reminder.yml
+++ b/.github/workflows/af_sync_reminder.yml
@@ -1,0 +1,93 @@
+name: AF Sync Staleness Reminder
+
+on:
+  schedule:
+    - cron: '47 9 * * 1'   # Mondays 09:47 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so the file's last commit date is real
+
+      - name: Measure links_af.json age
+        run: |
+          LAST=$(git log -1 --format=%ct -- src/links/links_af.json)
+          NOW=$(date +%s)
+          AGE_DAYS=$(( (NOW - LAST) / 86400 ))
+          # Repository variable AF_SYNC_STALE_DAYS overrides the 90-day default
+          THRESHOLD=${{ vars.AF_SYNC_STALE_DAYS || 90 }}
+          {
+            echo "AGE_DAYS=$AGE_DAYS"
+            echo "THRESHOLD=$THRESHOLD"
+            echo "LAST_SYNC=$(date -u -d @$LAST '+%-d %B %Y')"
+          } >> $GITHUB_ENV
+          echo "AF links last synced $AGE_DAYS days ago (threshold: $THRESHOLD days)"
+
+      - name: Open or close the reminder issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const stale = Number(process.env.AGE_DAYS) >= Number(process.env.THRESHOLD);
+            const TITLE = '🔄 AF Portal links sync overdue';
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.find(i => !i.pull_request && i.title === TITLE);
+
+            if (!stale) {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body: `✅ AF links were synced ${process.env.AGE_DAYS} days ago — under the ${process.env.THRESHOLD}-day threshold. Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                });
+                core.info(`Closed reminder #${existing.number}; links are fresh.`);
+              } else {
+                core.info('Links are fresh; nothing to do.');
+              }
+              return;
+            }
+
+            if (existing) {
+              core.info(`Reminder already open: #${existing.number}`);
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: TITLE,
+              assignees: ['dadatuputi'],
+              body: [
+                `The AF Portal links were last synced **${process.env.AGE_DAYS} days ago** (${process.env.LAST_SYNC}) — past the ${process.env.THRESHOLD}-day threshold.`,
+                '',
+                'To re-sync (~60 seconds, requires CAC):',
+                '',
+                '1. Open [Quick Links on the AF Portal](https://www.my.af.mil/gcss-af/USAF/ep/browse.do?categoryId=p7F11BC9F789430190178946F7E140005&channelPageId=sD22E5184744EFC540174558CFFA50008)',
+                '2. Open developer tools (F12) → Console, and paste the contents of [`getlinks.js`](https://raw.githubusercontent.com/dadatuputi/aflink/refs/heads/master/getlinks.js)',
+                '3. Copy the modal contents into a new [Update AF Links issue](https://github.com/dadatuputi/aflink/issues/new?template=04_link_update_af.yaml)',
+                '4. Close that issue to run the import — its success comment will show exactly what changed',
+                '',
+                '_This reminder closes itself on the next weekly check after the sync lands._',
+              ].join('\n'),
+            });
+            core.info('Opened a new sync reminder issue.');

--- a/.github/workflows/af_sync_reminder.yml
+++ b/.github/workflows/af_sync_reminder.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   check:
@@ -18,76 +17,31 @@ jobs:
         with:
           fetch-depth: 0   # full history so the file's last commit date is real
 
-      - name: Measure links_af.json age
+      - name: Check staleness and notify via Pushover
+        env:
+          # Pushover requires both: the application token and the user key
+          PUSHOVER_TOKEN: ${{ secrets.PUSHOVER_TOKEN }}
+          PUSHOVER_USER: ${{ secrets.PUSHOVER_KEY }}
         run: |
           LAST=$(git log -1 --format=%ct -- src/links/links_af.json)
           NOW=$(date +%s)
           AGE_DAYS=$(( (NOW - LAST) / 86400 ))
-          # Repository variable AF_SYNC_STALE_DAYS overrides the 90-day default
-          THRESHOLD=${{ vars.AF_SYNC_STALE_DAYS || 90 }}
-          {
-            echo "AGE_DAYS=$AGE_DAYS"
-            echo "THRESHOLD=$THRESHOLD"
-            echo "LAST_SYNC=$(date -u -d @$LAST '+%-d %B %Y')"
-          } >> $GITHUB_ENV
-          echo "AF links last synced $AGE_DAYS days ago (threshold: $THRESHOLD days)"
+          # Repository variable PORTAL_STALE_SINCE overrides the 90-day default
+          THRESHOLD=${{ vars.PORTAL_STALE_SINCE || 90 }}
+          LAST_SYNC=$(date -u -d @$LAST '+%-d %B %Y')
+          echo "AF links last synced $AGE_DAYS days ago on $LAST_SYNC (threshold: $THRESHOLD days)"
 
-      - name: Open or close the reminder issue
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const stale = Number(process.env.AGE_DAYS) >= Number(process.env.THRESHOLD);
-            const TITLE = '🔄 AF Portal links sync overdue';
-            const { data: open } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const existing = open.find(i => !i.pull_request && i.title === TITLE);
+          if [ "$AGE_DAYS" -lt "$THRESHOLD" ]; then
+            echo "Fresh enough; no notification."
+            exit 0
+          fi
 
-            if (!stale) {
-              if (existing) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: existing.number,
-                  body: `✅ AF links were synced ${process.env.AGE_DAYS} days ago — under the ${process.env.THRESHOLD}-day threshold. Closing.`,
-                });
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: existing.number,
-                  state: 'closed',
-                });
-                core.info(`Closed reminder #${existing.number}; links are fresh.`);
-              } else {
-                core.info('Links are fresh; nothing to do.');
-              }
-              return;
-            }
-
-            if (existing) {
-              core.info(`Reminder already open: #${existing.number}`);
-              return;
-            }
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: TITLE,
-              assignees: ['dadatuputi'],
-              body: [
-                `The AF Portal links were last synced **${process.env.AGE_DAYS} days ago** (${process.env.LAST_SYNC}) — past the ${process.env.THRESHOLD}-day threshold.`,
-                '',
-                'To re-sync (~60 seconds, requires CAC):',
-                '',
-                '1. Open [Quick Links on the AF Portal](https://www.my.af.mil/gcss-af/USAF/ep/browse.do?categoryId=p7F11BC9F789430190178946F7E140005&channelPageId=sD22E5184744EFC540174558CFFA50008)',
-                '2. Open developer tools (F12) → Console, and paste the contents of [`getlinks.js`](https://raw.githubusercontent.com/dadatuputi/aflink/refs/heads/master/getlinks.js)',
-                '3. Copy the modal contents into a new [Update AF Links issue](https://github.com/dadatuputi/aflink/issues/new?template=04_link_update_af.yaml)',
-                '4. Close that issue to run the import — its success comment will show exactly what changed',
-                '',
-                '_This reminder closes itself on the next weekly check after the sync lands._',
-              ].join('\n'),
-            });
-            core.info('Opened a new sync reminder issue.');
+          curl -sf \
+            --form-string "token=$PUSHOVER_TOKEN" \
+            --form-string "user=$PUSHOVER_USER" \
+            --form-string "title=aflink: AF Portal sync overdue" \
+            --form-string "message=Links last synced $AGE_DAYS days ago ($LAST_SYNC), past the $THRESHOLD-day threshold. Re-sync: portal Quick Links → getlinks.js in console → paste into an Update AF Links issue and close it." \
+            --form-string "url=https://github.com/dadatuputi/aflink/issues/new?template=04_link_update_af.yaml" \
+            --form-string "url_title=Open Update AF Links issue" \
+            https://api.pushover.net/1/messages.json
+          echo "Pushover notification sent."

--- a/.github/workflows/link_update_af.yml
+++ b/.github/workflows/link_update_af.yml
@@ -13,19 +13,41 @@ jobs:
       env:
         BODY: ${{ github.event.client_payload.issue_body }}
       run: |
-        B64=$(echo "$BODY" | sed -n 3p)
-        [[ -z $B64 ]] && exit 1
-        B64="B64=$B64"
-        echo $B64 | tr -d '[:space:]' | tee -a $GITHUB_ENV
+        # Extract the first non-blank line after the "### Compressed JSON"
+        # header, trimmed. Anchoring on the header (rather than sed line
+        # numbers) survives blank-line shifts and CRLF payloads.
+        field() {
+          printf '%s' "$BODY" | awk -v H="### $1" '
+            index($0, H) == 1 { found = 1; next }
+            found && $0 ~ /[^[:space:]]/ {
+              sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); print; exit
+            }'
+        }
+
+        B64=$(field "Compressed JSON" | tr -d '[:space:]')
+        [[ -z "$B64" ]] && { echo "Missing Compressed JSON"; exit 1; }
+        echo "B64=$B64" >> $GITHUB_ENV
 
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: Overwrite links with new link list
+    - name: Decode new link list
       run: |
-        JSON=$(echo ${{ env.B64 }} | base64 -d | gzip -dc)
-        echo "Decompressed data:"
-        echo "$JSON" | tee src/links/links_af.json
+        # Prettify so commits to links_af.json produce readable diffs
+        echo "${{ env.B64 }}" | base64 -d | gzip -dc | jq . > /tmp/links_af_new.json
+        echo "Decoded $(jq '[.afpCategorizedLinksDto.links[] | length] | add' /tmp/links_af_new.json) links"
+
+    - name: Compute import statistics
+      run: |
+        node scripts/af-import-stats.js src/links/links_af.json /tmp/links_af_new.json | tee /tmp/stats.txt
+        {
+          echo 'STATS<<STATS_EOF'
+          cat /tmp/stats.txt
+          echo 'STATS_EOF'
+        } >> $GITHUB_ENV
+
+    - name: Overwrite links with new link list
+      run: mv /tmp/links_af_new.json src/links/links_af.json
 
     - name: Commit New Changes
       uses: EndBug/add-and-commit@v9
@@ -55,6 +77,8 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: `✅ **AF Links updated successfully!**
-            
-            The AF links have been updated successfully. Nicely done.`
+
+            \`\`\`
+            ${{ env.STATS }}
+            \`\`\``
           })

--- a/scripts/af-import-stats.js
+++ b/scripts/af-import-stats.js
@@ -1,0 +1,36 @@
+// Compare two links_af.json files and print what an import changes.
+// Usage: node scripts/af-import-stats.js <old.json> <new.json>
+import fs from 'fs';
+
+// Output is interpolated into a JS template literal in the workflow's issue
+// comment; backticks or ${ in link titles would break out of it
+const say = s => console.log(s.replace(/[`$]/g, "'"));
+
+const flatten = file => {
+    const links = JSON.parse(fs.readFileSync(file)).afpCategorizedLinksDto.links;
+    const map = new Map();
+    for (const [cat, items] of Object.entries(links)) {
+        for (const l of items) map.set(l.contentId, { title: l.title, link: l.link, cat });
+    }
+    return map;
+};
+
+const [oldFile, newFile] = process.argv.slice(2);
+const oldMap = flatten(oldFile);
+const newMap = flatten(newFile);
+
+const added = [], removed = [], changed = [];
+for (const [id, l] of newMap) if (!oldMap.has(id)) added.push(l);
+for (const [id, l] of oldMap) if (!newMap.has(id)) removed.push(l);
+for (const [id, l] of newMap) {
+    const o = oldMap.get(id);
+    if (o && (o.title !== l.title || o.link !== l.link)) changed.push({ o, n: l });
+}
+
+say(`${newMap.size} links total: ${added.length} added, ${removed.length} removed, ${changed.length} changed`);
+for (const l of added) say(`+ ${l.title} (${l.cat})`);
+for (const l of removed) say(`- ${l.title} (${l.cat})`);
+for (const { o, n } of changed) {
+    if (o.title !== n.title) say(`~ title: "${o.title}" → "${n.title}"`);
+    if (o.link !== n.link) say(`~ url (${n.title}): ${o.link} → ${n.link}`);
+}

--- a/src/index.pug
+++ b/src/index.pug
@@ -43,7 +43,7 @@ html.bg-spice-brown(lang='en')
     .container
       .offcenter
         h2 Official Links
-        em.d-none.d-md-block Synced #{date}
+        em.d-none.d-md-block(title=sync_tooltip) Updated #{sync_display}
       div#link-list.list-group
         //- Links json is expanded here
         each category in links
@@ -88,10 +88,6 @@ html.bg-spice-brown(lang='en')
           a.nav-link(href='/overrides') Overrides
           if hasAnalytics
             a.nav-link(href='/analytics') Usage
-      .col
-        .text-end
-          em
-            | Synced with AF portal #{date} 
 
   include includes/foot.pug
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -43,7 +43,7 @@ html.bg-spice-brown(lang='en')
     .container
       .offcenter
         h2 Official Links
-        em.d-none.d-md-block(title=sync_tooltip) Updated #{sync_display}
+        em.d-none.d-md-block(title=sync_tooltip) Synced #{sync_display}
       div#link-list.list-group
         //- Links json is expanded here
         each category in links

--- a/updater.js
+++ b/updater.js
@@ -230,7 +230,9 @@ async function getNewestDate(files) {
             { stamp: newestOverride ? Math.floor(newestOverride.timestamp) : 0, name: overrideTargetName },
         ].filter(c => c.stamp && c.name).sort((a, b) => b.stamp - a.stamp)[0];
         const utcStamp = s => new Date(s * 1000).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
-        const sync_display = sugar_date.Date.format(new Date(Math.max(afSyncStamp, lastUpdate ? lastUpdate.stamp : 0) * 1000), '{d} {Month} {yyyy}');
+        // The visible date is the AF portal sync (transparency about source
+        // freshness); community link changes, possibly newer, live in the tooltip
+        const sync_display = sugar_date.Date.format(new Date(afSyncStamp * 1000), '{d} {Month} {yyyy}');
         const sync_tooltip = `AF Portal sync: ${utcStamp(afSyncStamp)}`
             + (lastUpdate ? `\nLast link update: ${lastUpdate.name} — ${utcStamp(lastUpdate.stamp)}` : '');
 

--- a/updater.js
+++ b/updater.js
@@ -98,8 +98,17 @@ async function getNewestDate(files) {
         const links_override = JSON.parse(fs.readFileSync(linksOverridePath));
         // Unofficial third-party links stay out of the official links object so
         // the override/delete workflows and links.json never touch them.
-        const links_unofficial = JSON.parse(fs.readFileSync(linksUnofficialPath)).UNOFFICIAL
+        const links_unofficial_raw = JSON.parse(fs.readFileSync(linksUnofficialPath)).UNOFFICIAL
+        const links_unofficial = [...links_unofficial_raw]
             .sort((a, b) => a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1);
+
+        // The workflows append new links, so the raw (pre-sort) last element
+        // names each file's most recent addition — used for the sync tooltip.
+        // An in-place edit bumps the file date but keeps the last-added name;
+        // close enough for a tooltip.
+        const lastOtherAdd = links_other.OTHER.length ? links_other.OTHER[links_other.OTHER.length - 1].title : null;
+        const lastUnofficialAdd = links_unofficial_raw.length ? links_unofficial_raw[links_unofficial_raw.length - 1].title : null;
+        const newestOverride = links_override.reduce((a, b) => (!a || b.timestamp > a.timestamp) ? b : a, null);
 
         // Sort other links
         links_other = {
@@ -195,6 +204,35 @@ async function getNewestDate(files) {
         const links_length = Object.values(links).reduce((sum, category) => sum + category.length, 0);
         console.log(`Combined ${links_length} links with ${override_count}/${links_override.length} overrides applied`)
 
+
+        // Sync display: the AF portal sync and the latest community link
+        // change are different events — the newer one drives the visible
+        // date, and the tooltip breaks out both with UTC timestamps.
+        const fileStamp = async p => {
+            const stamps = await gitDateExtractor.getStamps({ files: [p] });
+            const s = Object.values(stamps)[0];
+            return s ? Number(s.modified) : 0;
+        };
+        let overrideTargetName = newestOverride ? newestOverride.match : null;
+        if (newestOverride) {
+            for (const items of Object.values(links)) {
+                const hit = items.find(l => l.contentId === newestOverride.match);
+                if (hit) {
+                    overrideTargetName = hit.isDeleted ? (hit.originalTitle || hit.title) : hit.title;
+                    break;
+                }
+            }
+        }
+        const afSyncStamp = await fileStamp(linksAfPath);
+        const lastUpdate = [
+            { stamp: await fileStamp(linksOtherPath), name: lastOtherAdd },
+            { stamp: await fileStamp(linksUnofficialPath), name: lastUnofficialAdd },
+            { stamp: newestOverride ? Math.floor(newestOverride.timestamp) : 0, name: overrideTargetName },
+        ].filter(c => c.stamp && c.name).sort((a, b) => b.stamp - a.stamp)[0];
+        const utcStamp = s => new Date(s * 1000).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+        const sync_display = sugar_date.Date.format(new Date(Math.max(afSyncStamp, lastUpdate ? lastUpdate.stamp : 0) * 1000), '{d} {Month} {yyyy}');
+        const sync_tooltip = `AF Portal sync: ${utcStamp(afSyncStamp)}`
+            + (lastUpdate ? `\nLast link update: ${lastUpdate.name} — ${utcStamp(lastUpdate.stamp)}` : '');
 
         // Get links last modified date
         const dateFiles = [linksAfPath, linksOtherPath];
@@ -300,6 +338,8 @@ async function getNewestDate(files) {
             links,
             unofficial: links_unofficial,
             date,
+            sync_display,
+            sync_tooltip,
             hasAnalytics: !!analytics,
             announcements,
             isDev: environment !== 'production'

--- a/updater.js
+++ b/updater.js
@@ -112,6 +112,14 @@ async function getNewestDate(files) {
 
         let links = links_af.afpCategorizedLinksDto.links;
 
+        // Some AF portal links are relative paths (e.g. /gcss-af/...); make
+        // them absolute before overrides record originals or URLs are built
+        Object.values(links).forEach(items => items.forEach(link => {
+            if (link.link && link.link.startsWith('/')) {
+                link.link = 'https://www.my.af.mil' + link.link;
+            }
+        }));
+
         // Apply overrides to AF links - iterate through overrides looking for matches in links.
         // Apply in timestamp order so a link with multiple overrides ends in the newest state,
         // and record each application as a before/after event for the overrides page.
@@ -243,6 +251,8 @@ async function getNewestDate(files) {
             deletion.searchParams.append('template', '03_link_delete.yaml');
             deletion.searchParams.append('title', `[DELETE]: ${link.title}`);
             deletion.searchParams.append('match', link.contentId);
+            deletion.searchParams.append('current_title', link.title);
+            deletion.searchParams.append('current_url', link.link);
             link.deletion = deletion.toString();
         };
         links.forEach(category => category.links.forEach(addIssueUrls));


### PR DESCRIPTION
Clears four quick wins from the #51 comment thread, hardens the AF import pipeline, makes
source freshness visible on the homepage, and adds a weekly re-sync reminder via Pushover.

## What's included

### AF import quality
- **Readable diffs**: the import prettifies `links_af.json` through `jq` before committing, so
  future imports produce line-per-field diffs instead of one giant line. The first import after
  this merge will be a large formatting-only diff; every one after is clean.
- **Import statistics**: `scripts/af-import-stats.js` compares the incoming list to the previous
  one and reports totals plus per-link details (added / removed / retitled / re-URLed). The
  workflow logs the report and posts it in the issue's success comment. Output is sanitized so
  link titles containing backticks or `${` can't break the comment step.
- **Parser hardening**: `link_update_af.yml` parsed its payload with `sed -n 3p` — the same
  line-position fragility fixed in the other three workflows. Now anchored on the
  `### Compressed JSON` header.

### Link fixes
- **Absolute AF links**: the build prepends `https://www.my.af.mil` to relative portal links.
  This fixed 35 live links that were silently rendering as broken same-origin paths, and makes
  override records and issue prefills carry real URLs.
- **Delete-form details** (Jul 30 item): delete requests get the same locked 🔒 Current Link
  Title/URL reference fields the override form uses, so the issue body shows what's being
  deleted instead of a bare contentId.

### Sync-date transparency
- The homepage shows a single **"Synced <date>"** reflecting the AF portal sync — honest about
  source freshness. Hovering shows two UTC-timestamped lines: the portal sync, and the latest
  community link update (possibly newer) with the changed link's name. The redundant footer
  "Synced with AF portal" line is removed.

### Staleness reminder
- Mondays 09:47 UTC, a workflow measures the age of `links_af.json` from its last commit. Past
  the threshold — repository variable `PORTAL_STALE_SINCE`, defaulting to 90 days — it sends a
  **Pushover notification** with the age and a tap-through link to the Update AF Links issue
  template. Under threshold it exits quietly. `workflow_dispatch` enabled for manual testing.

## Setup
- `PUSHOVER_KEY` (user key) — already set.
- `PUSHOVER_TOKEN` (application token) — **required before the reminder can send**; register an
  app at pushover.net/apps/build and add it as a repository secret.
- `PORTAL_STALE_SINCE` repository variable — set to 90; read fresh each run, so threshold
  changes never need a commit.

## Testing
- Import pipeline simulated end-to-end locally: realistic multi-section issue body →
  header-anchored extraction of a 15KB base64 payload → decode/gunzip/prettify → stats against
  the real 190-link list (all four change types detected) → multiline env handoff in exact
  `$GITHUB_ENV` format.
- Build verified: 0 relative hrefs remain (35 absolutized), deletion URLs carry `current_*`
  params, "Synced 23 April 2026" renders with the two-line tooltip, all YAML parses.
- Staleness math verified locally: currently **102 days**, so the first reminder run (manual
  dispatch or Monday's cron) will notify immediately — that's the live test, not a bug.
- Not testable until merge: the delete-form fields (issue forms render from master), the
  success-comment rendering, the Pushover send, and a real import — the next
  `[Update AF Links]` issue doubles as that test.

Addresses the Dec 15, Apr 23 (both), and Jul 30 items from the #51 comment thread (does not
close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
