### PR TITLE
Dark mode: Night Watch palette with light/dark/auto toggle

### DIFF
--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -1,17 +1,183 @@
-section {padding:2rem;}
-/* 
+/*
 https://usafpatches.com/reference-shelf/palettes/
 https://coolors.co/000000-a09200-695b24-73391d-b0aa7e
+
+Theme tokens: light values match the original palette. Dark values are
+"Night Watch" — the whole site moves into deep slate blue rather than
+keeping the earth-tone hues at low light (that read as mud). Applied three
+ways: prefers-color-scheme for OS-auto/no-JS visitors, and explicit
+[data-theme] overrides (set by the toggle, see theme-toggle.js) that win in
+both directions over the OS preference.
 */
-.bg-sage {background-color:#B0AA7E; color:#fff;}
-.bg-bagby-green {background-color: #A09200; color:#fff;}
-.bg-olive-drab {background-color: #695B24; color: #fff;}
-.bg-spice-brown {background-color: #73391D; color: #fff;}
-.bg-cannes-blue {background-color: #7BAFD4; color: #fff;}
-.bg-slate-blue {background-color: #4F7396; color: #fff;}
+:root {
+  color-scheme: light;
+
+  --band-sage: #B0AA7E;
+  --band-bagby: #A09200;
+  --band-olive: #695B24;
+  --band-spice: #73391D;
+  --band-cannes: #7BAFD4;
+  --band-slate: #4F7396;
+  --band-ink: #fff;
+  --band-ink-faded: #ffffffad;
+
+  --card-bg: #fff;
+  --card-ink: #212529;
+  --card-border: rgba(0, 0, 0, 0.125);
+  --cat-bg: #efefef;
+  --cat-ink: #6c757d;
+  --muted: #6c757d;
+
+  --input-bg: #fff;
+  --input-ink: #212529;
+  --input-border: #ced4da;
+
+  --icon: #666;
+  --icon-hover: #333;
+  --mark-bg: rgba(123, 175, 212, 0.45);
+  --overridden-red: #ff0000;
+  --grid-line: #dee2e6;
+
+  --unofficial-card-bg: #fff;
+  --unofficial-card-ink: #212529;
+  --unofficial-card-border: rgba(0, 0, 0, 0.125);
+
+  --toggle-border: #ffffff55;
+  --toggle-ink: #ffffffb0;
+  --toggle-active-bg: #ffffff;
+  --toggle-active-ink: #73391D;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+
+    --band-sage: #171d24;
+    --band-bagby: #1a2430;
+    --band-olive: #131920;
+    --band-spice: #0f1419;
+    --band-cannes: #24455e;
+    --band-slate: #10161d;
+    --band-ink: #cfd9e2;
+    --band-ink-faded: #c9d4dead;
+
+    --card-bg: #212932;
+    --card-ink: #dfe6ec;
+    --card-border: #2a333d;
+    --cat-bg: #29323c;
+    --cat-ink: #93a1ae;
+    --muted: #93a1ae;
+
+    --input-bg: #212932;
+    --input-ink: #dfe6ec;
+    --input-border: #33414e;
+
+    --icon: #93a1ae;
+    --icon-hover: #d0dae2;
+    --mark-bg: rgba(123, 175, 212, 0.35);
+    --overridden-red: #ff8573;
+    --grid-line: #313c47;
+
+    --unofficial-card-bg: #1b2531;
+    --unofficial-card-ink: #d6e2ec;
+    --unofficial-card-border: #263241;
+
+    --toggle-border: #33414e;
+    --toggle-ink: #8fa1b1;
+    --toggle-active-bg: #7BAFD4;
+    --toggle-active-ink: #0f1419;
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --band-sage: #171d24;
+  --band-bagby: #1a2430;
+  --band-olive: #131920;
+  --band-spice: #0f1419;
+  --band-cannes: #24455e;
+  --band-slate: #10161d;
+  --band-ink: #cfd9e2;
+  --band-ink-faded: #c9d4dead;
+
+  --card-bg: #212932;
+  --card-ink: #dfe6ec;
+  --card-border: #2a333d;
+  --cat-bg: #29323c;
+  --cat-ink: #93a1ae;
+  --muted: #93a1ae;
+
+  --input-bg: #212932;
+  --input-ink: #dfe6ec;
+  --input-border: #33414e;
+
+  --icon: #93a1ae;
+  --icon-hover: #d0dae2;
+  --mark-bg: rgba(123, 175, 212, 0.35);
+  --overridden-red: #ff8573;
+  --grid-line: #313c47;
+
+  --unofficial-card-bg: #1b2531;
+  --unofficial-card-ink: #d6e2ec;
+  --unofficial-card-border: #263241;
+
+  --toggle-border: #33414e;
+  --toggle-ink: #8fa1b1;
+  --toggle-active-bg: #7BAFD4;
+  --toggle-active-ink: #0f1419;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --band-sage: #B0AA7E;
+  --band-bagby: #A09200;
+  --band-olive: #695B24;
+  --band-spice: #73391D;
+  --band-cannes: #7BAFD4;
+  --band-slate: #4F7396;
+  --band-ink: #fff;
+  --band-ink-faded: #ffffffad;
+
+  --card-bg: #fff;
+  --card-ink: #212529;
+  --card-border: rgba(0, 0, 0, 0.125);
+  --cat-bg: #efefef;
+  --cat-ink: #6c757d;
+  --muted: #6c757d;
+
+  --input-bg: #fff;
+  --input-ink: #212529;
+  --input-border: #ced4da;
+
+  --icon: #666;
+  --icon-hover: #333;
+  --mark-bg: rgba(123, 175, 212, 0.45);
+  --overridden-red: #ff0000;
+  --grid-line: #dee2e6;
+
+  --unofficial-card-bg: #fff;
+  --unofficial-card-ink: #212529;
+  --unofficial-card-border: rgba(0, 0, 0, 0.125);
+
+  --toggle-border: #ffffff55;
+  --toggle-ink: #ffffffb0;
+  --toggle-active-bg: #ffffff;
+  --toggle-active-ink: #73391D;
+}
+
+section {padding:2rem;}
+
+.bg-sage {background-color: var(--band-sage); color: var(--band-ink);}
+.bg-bagby-green {background-color: var(--band-bagby); color: var(--band-ink);}
+.bg-olive-drab {background-color: var(--band-olive); color: var(--band-ink);}
+.bg-spice-brown {background-color: var(--band-spice); color: var(--band-ink);}
+.bg-cannes-blue {background-color: var(--band-cannes); color: var(--band-ink);}
+.bg-slate-blue {background-color: var(--band-slate); color: var(--band-ink);}
 
 ul {
-  list-style-type: none;  
+  list-style-type: none;
 }
 
 .no-border {
@@ -24,10 +190,53 @@ ul {
 .no-dec:hover {
   text-decoration:none;
 }
- 
+
+/* Themed surfaces for Bootstrap components */
+.list-group-item {
+  background-color: var(--card-bg);
+  color: var(--card-ink);
+  border-color: var(--card-border);
+}
+
+#unofficial .list-group-item {
+  background-color: var(--unofficial-card-bg);
+  color: var(--unofficial-card-ink);
+  border-color: var(--unofficial-card-border);
+}
+
+.card {
+  background-color: var(--card-bg);
+  color: var(--card-ink);
+}
+
+.modal-content {
+  background-color: var(--card-bg);
+  color: var(--card-ink);
+}
+
+.form-control {
+  background-color: var(--input-bg);
+  color: var(--input-ink);
+  border-color: var(--input-border);
+}
+
+.form-control:focus {
+  background-color: var(--input-bg);
+  color: var(--input-ink);
+}
+
+.form-control::placeholder {
+  color: var(--muted);
+}
+
+.text-muted {
+  color: var(--muted) !important;
+}
+
 .container .category {
     padding: 0;
-    background-color: #efefef;
+    background-color: var(--cat-bg);
+    color: var(--cat-ink);
 }
 
 .modal-header .link {
@@ -47,7 +256,7 @@ ul {
   top: 50%;
   right: 0;
   transform: translateY(-25%);
-  color: #ffffffad
+  color: var(--band-ink-faded)
 }
 
 /* Correction link styling */
@@ -82,7 +291,7 @@ ul {
   opacity: 0;
   transition: opacity 0.2s ease;
   font-size: 0.9rem;
-  color: #666;
+  color: var(--icon);
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -104,11 +313,11 @@ ul {
 
 .override-link:hover {
   transform: translateY(-50%) scale(1.1);
-  color: #333;
+  color: var(--icon-hover);
 }
 
 .overridden {
-  text-decoration: underline dotted #ff0000 1px;
+  text-decoration: underline dotted var(--overridden-red) 1px;
 }
 
 /* Navbar group separators; only shown on the expanded (horizontal) bar */
@@ -135,8 +344,9 @@ section[id] {
 .category mark,
 #unofficial h2 mark {
   padding: 0;
-  background-color: rgba(123, 175, 212, 0.45);
+  background-color: var(--mark-bg);
   border-radius: 2px;
+  color: inherit;
 }
 
 /* CATEGORY MATCH pill: signals that the category name, not the link titles,
@@ -188,14 +398,14 @@ section[id] {
   font-size: 1.55rem;
   font-weight: 650;
   font-variant-numeric: tabular-nums;
-  color: #212529;
+  color: var(--card-ink);
 }
 
 .stat-tile .lbl {
   font-size: 0.72rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #6c757d;
+  color: var(--muted);
 }
 
 .usage-stack {
@@ -211,7 +421,7 @@ section[id] {
 .chart-title {
   font-size: 0.82rem;
   font-weight: 600;
-  color: #212529;
+  color: var(--card-ink);
   margin-bottom: 0.5rem;
   text-align: left;
 }
@@ -221,7 +431,7 @@ section[id] {
   align-items: flex-end;
   gap: 2px;
   height: 88px;
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid var(--grid-line);
 }
 
 .trend i {
@@ -239,7 +449,7 @@ section[id] {
   display: flex;
   justify-content: space-between;
   font-size: 0.7rem;
-  color: #6c757d;
+  color: var(--muted);
   margin-top: 0.25rem;
 }
 
@@ -258,7 +468,7 @@ section[id] {
 .rank .t {
   grid-column: 1;
   font-size: 0.82rem;
-  color: #212529;
+  color: var(--card-ink);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -267,7 +477,7 @@ section[id] {
 
 .rank .cat {
   font-size: 0.68rem;
-  color: #6c757d;
+  color: var(--muted);
   margin-left: 0.4rem;
 }
 
@@ -283,7 +493,7 @@ section[id] {
   grid-column: 2;
   grid-row: 1 / span 2;
   font-size: 0.8rem;
-  color: #212529;
+  color: var(--card-ink);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -298,4 +508,73 @@ section[id] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Dark-only component exceptions: pieces whose Bootstrap defaults assume a
+   light page and have no token to inherit. Gated on both the OS preference
+   (guarded against an explicit light override) and the explicit dark
+   override, so the toggle and "auto" agree. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .btn-outline-dark {
+    color: var(--card-ink);
+    border-color: var(--muted);
+  }
+
+  :root:not([data-theme="light"]) .btn-outline-dark:hover,
+  :root:not([data-theme="light"]) .btn-outline-dark.active {
+    background-color: var(--card-ink);
+    border-color: var(--card-ink);
+    color: var(--card-bg);
+  }
+
+  :root:not([data-theme="light"]) #list p.alert-dark {
+    color: var(--band-ink);
+  }
+}
+
+:root[data-theme="dark"] .btn-outline-dark {
+  color: var(--card-ink);
+  border-color: var(--muted);
+}
+
+:root[data-theme="dark"] .btn-outline-dark:hover,
+:root[data-theme="dark"] .btn-outline-dark.active {
+  background-color: var(--card-ink);
+  border-color: var(--card-ink);
+  color: var(--card-bg);
+}
+
+:root[data-theme="dark"] #list p.alert-dark {
+  color: var(--band-ink);
+}
+
+/* Theme toggle: light / dark / auto segmented control in the navbar.
+   Hidden until theme-toggle.js reveals it — no-JS visitors get "auto"
+   behavior for free via the prefers-color-scheme rules above. */
+.theme-toggle {
+  display: inline-flex;
+  border: 1px solid var(--toggle-border);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-left: 0.75rem;
+}
+
+.theme-toggle button {
+  background: none;
+  border: none;
+  color: var(--toggle-ink);
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+}
+
+.theme-toggle button.active {
+  background-color: var(--toggle-active-bg);
+  color: var(--toggle-active-ink);
+}
+
+.theme-toggle button:focus-visible {
+  outline: 2px solid var(--toggle-active-bg);
+  outline-offset: -2px;
 }

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -88,8 +88,8 @@ both directions over the OS preference.
     --toggle-ink: #8fa1b1;
     --toggle-active-bg: #7BAFD4;
     --toggle-active-ink: #1a2532;
-    --hover-bg: #17202b;
-    --active-bg: #10161e;
+    --hover-bg: #0b0f14;
+    --active-bg: #05070a;
   }
 }
 
@@ -130,8 +130,8 @@ both directions over the OS preference.
   --toggle-ink: #8fa1b1;
   --toggle-active-bg: #7BAFD4;
   --toggle-active-ink: #1a2532;
-  --hover-bg: #17202b;
-  --active-bg: #10161e;
+  --hover-bg: #0b0f14;
+  --active-bg: #05070a;
 }
 
 :root[data-theme="light"] {

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -52,23 +52,23 @@ both directions over the OS preference.
   :root {
     color-scheme: dark;
 
-    --band-sage: #171d24;
-    --band-bagby: #1a2430;
-    --band-olive: #131920;
-    --band-spice: #0f1419;
-    --band-cannes: #24455e;
-    --band-slate: #10161d;
+    --band-sage: #28394d;
+    --band-bagby: #1d2b3d;
+    --band-olive: #1f2c3d;
+    --band-spice: #1a2532;
+    --band-cannes: #38658a;
+    --band-slate: #212f40;
     --band-ink: #cfd9e2;
     --band-ink-faded: #c9d4dead;
 
-    --card-bg: #212932;
+    --card-bg: #2f435b;
     --card-ink: #dfe6ec;
     --card-border: #2a333d;
-    --cat-bg: #29323c;
+    --cat-bg: #364d68;
     --cat-ink: #93a1ae;
     --muted: #93a1ae;
 
-    --input-bg: #212932;
+    --input-bg: #2f435b;
     --input-ink: #dfe6ec;
     --input-border: #33414e;
 
@@ -76,39 +76,39 @@ both directions over the OS preference.
     --icon-hover: #d0dae2;
     --mark-bg: rgba(123, 175, 212, 0.35);
     --overridden-red: #ff8573;
-    --grid-line: #313c47;
+    --grid-line: #476385;
 
-    --unofficial-card-bg: #1b2531;
+    --unofficial-card-bg: #2b3e54;
     --unofficial-card-ink: #d6e2ec;
     --unofficial-card-border: #263241;
 
     --toggle-border: #33414e;
     --toggle-ink: #8fa1b1;
     --toggle-active-bg: #7BAFD4;
-    --toggle-active-ink: #0f1419;
+    --toggle-active-ink: #1a2532;
   }
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --band-sage: #171d24;
-  --band-bagby: #1a2430;
-  --band-olive: #131920;
-  --band-spice: #0f1419;
-  --band-cannes: #24455e;
-  --band-slate: #10161d;
+  --band-sage: #28394d;
+  --band-bagby: #1d2b3d;
+  --band-olive: #1f2c3d;
+  --band-spice: #1a2532;
+  --band-cannes: #38658a;
+  --band-slate: #212f40;
   --band-ink: #cfd9e2;
   --band-ink-faded: #c9d4dead;
 
-  --card-bg: #212932;
+  --card-bg: #2f435b;
   --card-ink: #dfe6ec;
   --card-border: #2a333d;
-  --cat-bg: #29323c;
+  --cat-bg: #364d68;
   --cat-ink: #93a1ae;
   --muted: #93a1ae;
 
-  --input-bg: #212932;
+  --input-bg: #2f435b;
   --input-ink: #dfe6ec;
   --input-border: #33414e;
 
@@ -116,16 +116,16 @@ both directions over the OS preference.
   --icon-hover: #d0dae2;
   --mark-bg: rgba(123, 175, 212, 0.35);
   --overridden-red: #ff8573;
-  --grid-line: #313c47;
+  --grid-line: #476385;
 
-  --unofficial-card-bg: #1b2531;
+  --unofficial-card-bg: #2b3e54;
   --unofficial-card-ink: #d6e2ec;
   --unofficial-card-border: #263241;
 
   --toggle-border: #33414e;
   --toggle-ink: #8fa1b1;
   --toggle-active-bg: #7BAFD4;
-  --toggle-active-ink: #0f1419;
+  --toggle-active-ink: #1a2532;
 }
 
 :root[data-theme="light"] {

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -70,9 +70,9 @@ both directions over the OS preference.
     --cat-ink: #93a1ae;
     --muted: #93a1ae;
 
-    --input-bg: #3e5774;
+    --input-bg: #4b688b;
     --input-ink: #dfe6ec;
-    --input-border: #506f95;
+    --input-border: #6d8bb0;
 
     --icon: #93a1ae;
     --icon-hover: #d0dae2;
@@ -88,8 +88,8 @@ both directions over the OS preference.
     --toggle-ink: #8fa1b1;
     --toggle-active-bg: #7BAFD4;
     --toggle-active-ink: #1a2532;
-    --hover-bg: #243142;
-    --active-bg: #1d2835;
+    --hover-bg: #17202b;
+    --active-bg: #10161e;
   }
 }
 
@@ -112,9 +112,9 @@ both directions over the OS preference.
   --cat-ink: #93a1ae;
   --muted: #93a1ae;
 
-  --input-bg: #3e5774;
+  --input-bg: #4b688b;
   --input-ink: #dfe6ec;
-  --input-border: #506f95;
+  --input-border: #6d8bb0;
 
   --icon: #93a1ae;
   --icon-hover: #d0dae2;
@@ -130,8 +130,8 @@ both directions over the OS preference.
   --toggle-ink: #8fa1b1;
   --toggle-active-bg: #7BAFD4;
   --toggle-active-ink: #1a2532;
-  --hover-bg: #243142;
-  --active-bg: #1d2835;
+  --hover-bg: #17202b;
+  --active-bg: #10161e;
 }
 
 :root[data-theme="light"] {

--- a/src/includes/css/site.css
+++ b/src/includes/css/site.css
@@ -46,6 +46,8 @@ both directions over the OS preference.
   --toggle-ink: #ffffffb0;
   --toggle-active-bg: #ffffff;
   --toggle-active-ink: #73391D;
+  --hover-bg: #f8f9fa;
+  --active-bg: #e9ecef;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -68,9 +70,9 @@ both directions over the OS preference.
     --cat-ink: #93a1ae;
     --muted: #93a1ae;
 
-    --input-bg: #2f435b;
+    --input-bg: #3e5774;
     --input-ink: #dfe6ec;
-    --input-border: #33414e;
+    --input-border: #506f95;
 
     --icon: #93a1ae;
     --icon-hover: #d0dae2;
@@ -86,6 +88,8 @@ both directions over the OS preference.
     --toggle-ink: #8fa1b1;
     --toggle-active-bg: #7BAFD4;
     --toggle-active-ink: #1a2532;
+    --hover-bg: #243142;
+    --active-bg: #1d2835;
   }
 }
 
@@ -108,9 +112,9 @@ both directions over the OS preference.
   --cat-ink: #93a1ae;
   --muted: #93a1ae;
 
-  --input-bg: #2f435b;
+  --input-bg: #3e5774;
   --input-ink: #dfe6ec;
-  --input-border: #33414e;
+  --input-border: #506f95;
 
   --icon: #93a1ae;
   --icon-hover: #d0dae2;
@@ -126,6 +130,8 @@ both directions over the OS preference.
   --toggle-ink: #8fa1b1;
   --toggle-active-bg: #7BAFD4;
   --toggle-active-ink: #1a2532;
+  --hover-bg: #243142;
+  --active-bg: #1d2835;
 }
 
 :root[data-theme="light"] {
@@ -165,6 +171,22 @@ both directions over the OS preference.
   --toggle-ink: #ffffffb0;
   --toggle-active-bg: #ffffff;
   --toggle-active-ink: #73391D;
+  --hover-bg: #f8f9fa;
+  --active-bg: #e9ecef;
+}
+
+/* Route Bootstrap's list-group-action hover/active colors through our
+   tokens instead of its fixed grays — otherwise dark mode hovers flash a
+   near-white bar (Bootstrap's unthemed default), and the hover text color
+   quietly diverges from --card-ink even in light mode. One mapping serves
+   every theme block above, since it only references already-resolved
+   tokens. */
+:root {
+  --bs-list-group-action-color: var(--card-ink);
+  --bs-list-group-action-hover-color: var(--card-ink);
+  --bs-list-group-action-hover-bg: var(--hover-bg);
+  --bs-list-group-action-active-color: var(--card-ink);
+  --bs-list-group-action-active-bg: var(--active-bg);
 }
 
 section {padding:2rem;}

--- a/src/includes/foot.pug
+++ b/src/includes/foot.pug
@@ -3,9 +3,14 @@ script
     include js/jquery-3.5.1.slim.min.js
   else
     include:uglify-js js/jquery-3.5.1.slim.min.js
-script 
+script
   include js/bootstrap.bundle.5.2.3.min.js
-script 
+script
+  if isDev
+    include js/theme-toggle.js
+  else
+    include:uglify-js js/theme-toggle.js
+script
   if isDev
     include js/search.js
   else

--- a/src/includes/head.pug
+++ b/src/includes/head.pug
@@ -16,9 +16,30 @@ head
     //- PWA: installable app manifest and home-screen icon
     link(rel='manifest' href='/manifest.json')
     link(rel='apple-touch-icon' href='/icon-192.png')
-    meta(name='theme-color' content='#73391D')
+    //- Single theme-color tag, kept in sync with the resolved theme by both
+    //- the inline script below (first paint) and theme-toggle.js (later
+    //- changes) — simpler and more correct than dueling media-scoped tags,
+    //- which can't express "explicitly light even though the OS is dark".
+    meta#theme-color(name='theme-color' content='#73391D')
 
-    
+    //- Anti-flash: apply a saved theme choice, and match the theme-color
+    //- meta to it, before first paint. Runs synchronously and inline (not
+    //- deferred) so there is no flash of the wrong theme. Absence of a
+    //- saved choice (or "auto") leaves data-theme unset and falls back to
+    //- the OS preference — same resolved appearance as a no-JS visitor.
+    script.
+      (function () {
+        try {
+          var t = localStorage.getItem('aflink-theme');
+          var dark = t === 'dark' || (t !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (t === 'light' || t === 'dark') {
+            document.documentElement.setAttribute('data-theme', t);
+          }
+          document.getElementById('theme-color').setAttribute('content', dark ? '#0f1419' : '#73391D');
+        } catch (e) {}
+      })();
+
+
     //- CSS
     style
       include css/bootstrap.5.2.3.min.css
@@ -39,6 +60,13 @@ mixin navigation
       button.navbar-toggler(type='button' data-bs-toggle='collapse' data-bs-target='#navbarResponsive' aria-controls='navbarResponsive' aria-expanded='false' aria-label='Toggle navigation')
         span.navbar-toggler-icon
       #navbarResponsive.collapse.navbar-collapse
-        .navbar-nav.ms-auto
+        .navbar-nav.ms-auto.align-items-lg-center
           a.nav-link(aria-current='page' href='/') Home
           block
+          //- Light/dark/auto toggle, rightmost in the bar. Hidden until
+          //- theme-toggle.js reveals it — no-JS visitors just follow the
+          //- OS preference (prefers-color-scheme rules in site.css).
+          .theme-toggle#theme-toggle(hidden role='group' aria-label='Theme')
+            button(type='button' data-theme-choice='light' aria-label='Light theme') ☀
+            button(type='button' data-theme-choice='dark' aria-label='Dark theme') ☾
+            button(type='button' data-theme-choice='auto' aria-label='Match system theme') A

--- a/src/includes/js/theme-toggle.js
+++ b/src/includes/js/theme-toggle.js
@@ -1,0 +1,62 @@
+// Light/dark/auto theme toggle. Progressive enhancement: the control ships
+// `hidden` in the markup (see the navigation mixin in head.pug) and this
+// script reveals it, so no-JS visitors simply follow prefers-color-scheme —
+// identical to what "auto" resolves to here.
+(function () {
+  var STORAGE_KEY = 'aflink-theme';
+  var toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+
+  var media = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function getSaved() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function applyThemeColor() {
+    var saved = getSaved();
+    var dark = saved === 'dark' || (saved !== 'light' && media.matches);
+    var meta = document.getElementById('theme-color');
+    if (meta) meta.setAttribute('content', dark ? '#0f1419' : '#73391D');
+  }
+
+  function setActiveButton() {
+    var saved = getSaved();
+    var current = saved === 'light' || saved === 'dark' ? saved : 'auto';
+    toggle.querySelectorAll('button').forEach(function (btn) {
+      btn.classList.toggle('active', btn.getAttribute('data-theme-choice') === current);
+    });
+  }
+
+  function choose(value) {
+    try {
+      if (value === 'auto') localStorage.removeItem(STORAGE_KEY);
+      else localStorage.setItem(STORAGE_KEY, value);
+    } catch (e) {}
+
+    if (value === 'light' || value === 'dark') {
+      document.documentElement.setAttribute('data-theme', value);
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+    applyThemeColor();
+    setActiveButton();
+  }
+
+  toggle.addEventListener('click', function (e) {
+    var btn = e.target.closest('button[data-theme-choice]');
+    if (btn) choose(btn.getAttribute('data-theme-choice'));
+  });
+
+  // Keep theme-color correct if the OS preference changes while on "auto"
+  media.addEventListener('change', function () {
+    if (getSaved() !== 'light' && getSaved() !== 'dark') applyThemeColor();
+  });
+
+  setActiveButton();
+  toggle.hidden = false;
+})();


### PR DESCRIPTION
Addresses the Dec 2 dark-mode item from the #51 comment thread.

## What's included

### Palette — "Night Watch" (dusk blue)
Round 1 kept the OCP earth-tone hues at low light and read as mud in review. Night Watch is a
genuine palette shift instead: the whole site moves into a dusk-blue family at night rather than
a darkened version of the day palette — earth-tone identity in light mode, blue-
